### PR TITLE
Replace full width colon to half width colon in English version

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -33,9 +33,9 @@ If you are unsure whether your project meets this list's criteria, please contac
 #### z-song(Shanghai) - [Github](https://github.com/z-song)
 * :white_check_mark: [implode.io](https://implode.io/) - A website that runs, records, and shares PHP code online
 #### Eureka Chen - [GitHub](https://github.com/EurekaChen), [Web](https://eureka.name) [Blog](https://eeblog.net) 
-* :white_check_mark: [Eureka Clock](http://www.9192631770.com/)：Eureka Clock.
-* :white_check_mark: [Colorful Iching](https://eeeeee.org/e)：Iching with full text colorful.
-* :white_check_mark: [Eureka Url](https://eeurl.com)：ShortUrl or Pastebin in a short url customed by you.
+* :white_check_mark: [Eureka Clock](http://www.9192631770.com/): Eureka Clock.
+* :white_check_mark: [Colorful Iching](https://eeeeee.org/e): Iching with full text colorful.
+* :white_check_mark: [Eureka Url](https://eeurl.com): ShortUrl or Pastebin in a short url customed by you.
 
 ### Feb 28, 2019
 ---
@@ -48,7 +48,7 @@ If you are unsure whether your project meets this list's criteria, please contac
 ### July 16, 2018
 ---
 #### brucefeynman - [Github](https://github.com/brucefeynman)
-* :white_check_mark: [51% attack analysis](http://www.cryptoattack.io/)：Using cost and profit analysis to find the vulnerability of different tokens - [More Info](http://www.cryptoattack.io/about)
+* :white_check_mark: [51% attack analysis](http://www.cryptoattack.io/): Using cost and profit analysis to find the vulnerability of different tokens - [More Info](http://www.cryptoattack.io/about)
 
 ### March 28, 2018
 ---
@@ -58,402 +58,402 @@ If you are unsure whether your project meets this list's criteria, please contac
 ### March 22, 2018
 
 #### Jianqing - [GitHub](https://github.com/pjq), [Blog](https://pjq.me)
-* :clock8: [Smart Car on Raspberry Pi](https://github.com/pjq/rpi)：Smart car for delight my cats remotely, build on Raspberry Pi
-* :white_check_mark: [Weather Station on Raspberry Pi](http://rpi.pjq.me/)：RealTime Weather Station build on Raspberry Pi, monitor PM2.5/Temperature/Humidity, etc.  - [More Info](https://github.com/pjq/rpi#weather-station-demo)
+* :clock8: [Smart Car on Raspberry Pi](https://github.com/pjq/rpi): Smart car for delight my cats remotely, build on Raspberry Pi
+* :white_check_mark: [Weather Station on Raspberry Pi](http://rpi.pjq.me/): RealTime Weather Station build on Raspberry Pi, monitor PM2.5/Temperature/Humidity, etc.  - [More Info](https://github.com/pjq/rpi#weather-station-demo)
 
 #### HansChen - [GitHub](https://github.com/shensky711), [Blog](http://blog.hanschen.site/)
-* :clock8: [Pretty-Zhihu](https://github.com/shensky711/Pretty-Zhihu)：Pretty image grabber for ZhiHu
-* :clock8: [Run-With-You](https://github.com/shensky711/Run-With-You)：Double Runner App
+* :clock8: [Pretty-Zhihu](https://github.com/shensky711/Pretty-Zhihu): Pretty image grabber for ZhiHu
+* :clock8: [Run-With-You](https://github.com/shensky711/Run-With-You): Double Runner App
 
 #### Miko Gao - [GitHub](https://github.com/gaowhen)
-* :white_check_mark: [viewpre.com](https://viewpre.com/)：Kindle Clippings Management Web App 
+* :white_check_mark: [viewpre.com](https://viewpre.com/): Kindle Clippings Management Web App 
 
 #### aizuyan - [GitHub](https://github.com/aizuyan)
-* :white_check_mark: [GramTools](https://ritoyantools.github.io/)：Cross-platform tool collection（now have json、diff tool）
+* :white_check_mark: [GramTools](https://ritoyantools.github.io/): Cross-platform tool collection（now have json、diff tool）
 
 ### March 21, 2018
 
 #### Airing - [GitHub](https://github.com/airingursb), [Blog](http://ursb.me)
-- :white_check_mark: [四时](https://itunes.apple.com/us/app/%E5%9B%9B%E6%97%B6/id1272513774?l=zh&ls=1&mt=8)：Shiny Weather App - [More Details](https://github.com/airingursb/4times-front-end)
-- :clock8: [双生](https://github.com/oh-bear/2life)：The beauty of meeting the other half（Shared Diary）
+- :white_check_mark: [四时](https://itunes.apple.com/us/app/%E5%9B%9B%E6%97%B6/id1272513774?l=zh&ls=1&mt=8): Shiny Weather App - [More Details](https://github.com/airingursb/4times-front-end)
+- :clock8: [双生](https://github.com/oh-bear/2life): The beauty of meeting the other half（Shared Diary）
 
 #### Arczzir - [GitHub](https://github.com/arczzir)
-* :white_check_mark: [Jed](https://itunes.apple.com/cn/app/jed/id1234853584)：macOS JSON file editor - [More Info](https://www.bilibili.com/video/av10147282/)
+* :white_check_mark: [Jed](https://itunes.apple.com/cn/app/jed/id1234853584): macOS JSON file editor - [More Info](https://www.bilibili.com/video/av10147282/)
 
 #### Drinking - [GitHub](https://github.com/drinking), [Blog](http://drinking.github.io/)
-* :white_check_mark: [饭起](https://itunes.apple.com/cn/app/%E9%A5%AD%E8%B5%B7-%E5%85%B3%E4%BA%8E%E9%A3%9F%E7%89%A9%E7%9A%84%E7%88%B1%E4%B8%8E%E6%95%85%E4%BA%8B/id1209331941?mt=8)：Stories and love of food  - [More Details](http://fancymeet.com/)
+* :white_check_mark: [饭起](https://itunes.apple.com/cn/app/%E9%A5%AD%E8%B5%B7-%E5%85%B3%E4%BA%8E%E9%A3%9F%E7%89%A9%E7%9A%84%E7%88%B1%E4%B8%8E%E6%95%85%E4%BA%8B/id1209331941?mt=8): Stories and love of food  - [More Details](http://fancymeet.com/)
 
 #### Yuuta - [GitHub](https://github.com/Trumeet), [Website](https://yuuta.moe)
-* :white_check_mark: [Dir](https://coolapk.com/apk/kh.android.dir)：a simple and elegant Android trash file clean tool, prevent file from re-generate - [More Details](https://dir.yuuta.moe/zh/)  
+* :white_check_mark: [Dir](https://coolapk.com/apk/kh.android.dir): a simple and elegant Android trash file clean tool, prevent file from re-generate - [More Details](https://dir.yuuta.moe/zh/)  
 
 #### 曦莫琅 - [GitHub](https://github.com/ximolang), [Blog](http://www.txliang.com/)
-* :white_check_mark: [诗说社](http://shishuo.wesnice.com/)：A gathering place for young artists and a publishing platform for orginal poetries.
+* :white_check_mark: [诗说社](http://shishuo.wesnice.com/): A gathering place for young artists and a publishing platform for orginal poetries.
 
 #### ruzhan123 - [GitHub](https://github.com/ruzhan123)
-* :white_check_mark: [Awaker](https://www.coolapk.com/apk/155953)：An Android app for science fictions and geographical magazines - [More Details](https://github.com/ruzhan123/awaker)
+* :white_check_mark: [Awaker](https://www.coolapk.com/apk/155953): An Android app for science fictions and geographical magazines - [More Details](https://github.com/ruzhan123/awaker)
 
 #### cwang22 - [GitHub](https://github.com/cwang22), [Blog](https://seewang.me)
-* :white_check_mark: [Buy All Steam Games](http://steam.seewang.me)：How much you money do you need to buy all Stream games?
+* :white_check_mark: [Buy All Steam Games](http://steam.seewang.me): How much you money do you need to buy all Stream games?
 
 #### santa - [GitHub](https://github.com/santa-cat)
-* :white_check_mark: [一天](https://fir.im/oneday)：A social app for making friends in 24hr (Android、iOS)
+* :white_check_mark: [一天](https://fir.im/oneday): A social app for making friends in 24hr (Android、iOS)
 
 #### Caij - [GitHub](https://github.com/Caij)
-* :white_check_mark: [EMore](https://www.coolapk.com/apk/com.caij.emore)：A simple and light-weight, third-party client application of weibo. 
+* :white_check_mark: [EMore](https://www.coolapk.com/apk/com.caij.emore): A simple and light-weight, third-party client application of weibo. 
 
 
 ### 2018, March 20
 ---
 
 #### fujianjin6471
-* :white_check_mark: [Memory Helper](https://itunes.apple.com/cn/app/memory-helper-zi-ding-yi-nei/id1113262919?l=en&mt=8)：科学复习，真正记住知识
+* :white_check_mark: [Memory Helper](https://itunes.apple.com/cn/app/memory-helper-zi-ding-yi-nei/id1113262919?l=en&mt=8): 科学复习，真正记住知识
 
 #### DeweyReed - [GitHub](https://github.com/DeweyReed)
-* :clock8: [剪贴板守护](https://github.com/DeweyReed/ClipboardCleaner)：使用多种方式查看并清空剪贴板的开源 Android 应用
-* :white_check_mark: [权限图书馆](https://www.coolapk.com/apk/162565)：查看本设备的应用和安装包的权限的 Android 应用
-* :white_check_mark: [循环计时器](https://www.coolapk.com/apk/118705)：一次设置N个计时器，自动计时、自动通知的 Android 应用
-* :clock8: [计时机器](https://www.coolapk.com/apk/177033)：循环计时器加强版，更多的通知方式和计划任务
+* :clock8: [剪贴板守护](https://github.com/DeweyReed/ClipboardCleaner): 使用多种方式查看并清空剪贴板的开源 Android 应用
+* :white_check_mark: [权限图书馆](https://www.coolapk.com/apk/162565): 查看本设备的应用和安装包的权限的 Android 应用
+* :white_check_mark: [循环计时器](https://www.coolapk.com/apk/118705): 一次设置N个计时器，自动计时、自动通知的 Android 应用
+* :clock8: [计时机器](https://www.coolapk.com/apk/177033): 循环计时器加强版，更多的通知方式和计划任务
 
 #### HyanCat - [GitHub](https://github.com/HyanCat), [博客](https://hyancat.com)
-* :white_check_mark: [若古](https://www.ruogoo.cn)： 古风文学兴趣交流社区（网站和 App）- [更多介绍](https://www.ruogoo.cn/about)
+* :white_check_mark: [若古](https://www.ruogoo.cn):  古风文学兴趣交流社区（网站和 App）- [更多介绍](https://www.ruogoo.cn/about)
 
 #### luowei - [GitHub](https://github.com/luowei)
-* :white_check_mark: [万能输入法](http://app.wodedata.com)：一个支持拼音、五笔、笔画、手写、特殊符号及动画表情的输入法
-* :white_check_mark: [我的浏览器](http://app.wodedata.com/myapp/mybrowser.html)：一个支持截图导出 PDF 的可个性化的自定义浏览器 - [更多介绍](https://github.com/luowei/MyBrowser)  
-* :white_check_mark: [照片DIY](http://app.wodedata.com/myapp/photodiy.html)：一款可以对图片加滤镜、各种涂鸭、打码塞克、裁剪的 APP - [更多介绍](https://github.com/luowei/PhotoDIY)  
-* :white_check_mark: [斗图王](http://app.wodedata.com/myapp/gifemoji.html)：一个 GIF 斗图动画表情制作和搜索 APP，兼具斗图浏览器与斗图编辑器的功能
-* :white_check_mark: [美图王](http://app.wodedata.com/myapp/mywallpaper.html)：一款高清的意向图和壁纸图片应用 
-* :white_check_mark: [Mark记事本](http://app.wodedata.com/myapp/mymarkdown.html)：一款 Markdown 记事本，支持从文本图片导入及导出 PDF 
-* :white_check_mark: [最强二维码](http://app.wodedata.com/myapp/qrcoderobot.html)：一个可以扫描二维码和生成自定义二维码的 App
+* :white_check_mark: [万能输入法](http://app.wodedata.com): 一个支持拼音、五笔、笔画、手写、特殊符号及动画表情的输入法
+* :white_check_mark: [我的浏览器](http://app.wodedata.com/myapp/mybrowser.html): 一个支持截图导出 PDF 的可个性化的自定义浏览器 - [更多介绍](https://github.com/luowei/MyBrowser)  
+* :white_check_mark: [照片DIY](http://app.wodedata.com/myapp/photodiy.html): 一款可以对图片加滤镜、各种涂鸭、打码塞克、裁剪的 APP - [更多介绍](https://github.com/luowei/PhotoDIY)  
+* :white_check_mark: [斗图王](http://app.wodedata.com/myapp/gifemoji.html): 一个 GIF 斗图动画表情制作和搜索 APP，兼具斗图浏览器与斗图编辑器的功能
+* :white_check_mark: [美图王](http://app.wodedata.com/myapp/mywallpaper.html): 一款高清的意向图和壁纸图片应用 
+* :white_check_mark: [Mark记事本](http://app.wodedata.com/myapp/mymarkdown.html): 一款 Markdown 记事本，支持从文本图片导入及导出 PDF 
+* :white_check_mark: [最强二维码](http://app.wodedata.com/myapp/qrcoderobot.html): 一个可以扫描二维码和生成自定义二维码的 App
 
 #### aderm - [GitHub](https://github.com/aderm)
-* :clock8: [如e定制](http://www.shangyuekeji.com/download)：个性化定制加工平台
+* :clock8: [如e定制](http://www.shangyuekeji.com/download): 个性化定制加工平台
 
 #### TKkk - [GitHub](https://github.com/TKkk-iOSer)
-* :white_check_mark: [WeChatPlugin-MacOS](https://github.com/TKkk-iOSer/WeChatPlugin-MacOS)：MacOS 微信小助手（可玩性很高，开源）
+* :white_check_mark: [WeChatPlugin-MacOS](https://github.com/TKkk-iOSer/WeChatPlugin-MacOS): MacOS 微信小助手（可玩性很高，开源）
 
 #### maomao1996（茂茂） - [Github](https://github.com/maomao1996)
-* :white_check_mark: [mmPlayer在线音乐播放器](http://music.mtnhao.com)：在线音乐播放器（基于Vue2）（PC） - [更多介绍](https://github.com/maomao1996/Vue-mmPlayer)
+* :white_check_mark: [mmPlayer在线音乐播放器](http://music.mtnhao.com): 在线音乐播放器（基于Vue2）（PC） - [更多介绍](https://github.com/maomao1996/Vue-mmPlayer)
 
 #### genru - [GitHub](https://github.com/genru)
-* :white_check_mark: [每日壹单](https://mryd.freeflarum.com)：每天推送10条最新外包兼职信息
+* :white_check_mark: [每日壹单](https://mryd.freeflarum.com): 每天推送10条最新外包兼职信息
 
 #### SpongeBobSun - [GitHub](https://github.com/SpongeBobSun/)
-* :white_check_mark: [Puff Password Manager](https://itunes.apple.com/cn/app/puff-password-manager-open-source-free/id1183663532?mt=8)：开源免费的离线密码管理器 - [更多介绍](https://puffopensource.github.io/)
-* :white_check_mark: [Prodigal Music Player](https://itunes.apple.com/cn/app/prodigal-music-player/id1231296263?mt=8)：复刻经典 iPod 的音乐播放器 - [更多介绍](http://spongebobsun.github.io/Prodigal/)
+* :white_check_mark: [Puff Password Manager](https://itunes.apple.com/cn/app/puff-password-manager-open-source-free/id1183663532?mt=8): 开源免费的离线密码管理器 - [更多介绍](https://puffopensource.github.io/)
+* :white_check_mark: [Prodigal Music Player](https://itunes.apple.com/cn/app/prodigal-music-player/id1231296263?mt=8): 复刻经典 iPod 的音乐播放器 - [更多介绍](http://spongebobsun.github.io/Prodigal/)
 
 #### Sing - [GitHub](https://github.com/asing1001), [博客](https://www.paddingleft.com)
-* :white_check_mark: [MovieRater](https://www.mvrater.com)：Combine Yahoo, Ptt, IMDB score, help you choose movie - [更多介绍](https://github.com/Asing1001/movieRater.React)
+* :white_check_mark: [MovieRater](https://www.mvrater.com): Combine Yahoo, Ptt, IMDB score, help you choose movie - [更多介绍](https://github.com/Asing1001/movieRater.React)
 
 #### Chars - [GitHub](https://github.com/charsdavy), [博客](http://chars.tech), [Twitter](https://twitter.com/charsdavy)
-* :white_check_mark: [日本语社区](https://itunes.apple.com/cn/app/id1184113889)：日语学习资源，整合各种文本、音频和视频学习资料
-* :white_check_mark: [今日账单](https://itunes.apple.com/cn/app/id1176787145)：帐单记录与数据分析，内含云备份功能，界面简洁清爽
-* :white_check_mark: [Piclip](https://itunes.apple.com/cn/app/id1188174656)：即兴想起的一款九宫格切图软件，当然还有六、四等宫格布局
-* :white_check_mark: [牛皮纸](https://itunes.apple.com/cn/app/id1346384976)： 一款阅读 Github 上 md 文档的工具，支持浏览远程 md 文档
-* :white_check_mark: [ImageHosting for Mac](https://github.com/charsdavy/ImageHosting)：七牛云图床上载工具 (开源)
+* :white_check_mark: [日本语社区](https://itunes.apple.com/cn/app/id1184113889): 日语学习资源，整合各种文本、音频和视频学习资料
+* :white_check_mark: [今日账单](https://itunes.apple.com/cn/app/id1176787145): 帐单记录与数据分析，内含云备份功能，界面简洁清爽
+* :white_check_mark: [Piclip](https://itunes.apple.com/cn/app/id1188174656): 即兴想起的一款九宫格切图软件，当然还有六、四等宫格布局
+* :white_check_mark: [牛皮纸](https://itunes.apple.com/cn/app/id1346384976):  一款阅读 Github 上 md 文档的工具，支持浏览远程 md 文档
+* :white_check_mark: [ImageHosting for Mac](https://github.com/charsdavy/ImageHosting): 七牛云图床上载工具 (开源)
 
 #### enzo-yang - [GitHub](https://github.com/enzo-yang)
-* :white_check_mark: [集木](https://itunes.apple.com/cn/app/%E9%9B%86%E6%9C%A8/id1273031712?mt=8)：丰富的植物库以及拍照识别植物
+* :white_check_mark: [集木](https://itunes.apple.com/cn/app/%E9%9B%86%E6%9C%A8/id1273031712?mt=8): 丰富的植物库以及拍照识别植物
 
 #### miliPolo - [GitHub](https://github.com/miliPolo), [简书](https://www.jianshu.com/u/e9f2e9d46877)
-* :clock8: [AR太阳系](https://github.com/miliPolo/ARSolarPlaySwift)：showcase how solar system work
+* :clock8: [AR太阳系](https://github.com/miliPolo/ARSolarPlaySwift): showcase how solar system work
 
 #### xx19941215 - [GitHub](https://github.com/xx19941215)
-* :white_check_mark: [小时光倒数日](https://minapp.com/miniapp/2810/)：小时光倒数日，帮你铭记人生每一次的幸福时光
+* :white_check_mark: [小时光倒数日](https://minapp.com/miniapp/2810/): 小时光倒数日，帮你铭记人生每一次的幸福时光
 
 #### JY - [GitHub](https://github.com/jy1989)
-* :white_check_mark: [狗狗大全](https://play.google.com/store/apps/details?id=com.cjy.DogCollection)：展示狗狗特性、概述、性格等，Android App
+* :white_check_mark: [狗狗大全](https://play.google.com/store/apps/details?id=com.cjy.DogCollection): 展示狗狗特性、概述、性格等，Android App
 
 #### 钟颖 - [GitHub](https://github.com/cyanzhong/), [小专栏](https://xiaozhuanlan.com/devnotes), [微博](https://weibo.com/0x00eeee)
 
-- :white_check_mark: [JSBox](https://itunes.apple.com/cn/app/id1312014438)：用 JavaScript 实现原生小工具 - [更多介绍](https://sspai.com/post/42361)
-- :white_check_mark: [TodayMind](https://itunes.apple.com/cn/app/id1207158665)：提醒事项扩展小组件 - [更多介绍](https://sspai.com/post/37669)
-- :white_check_mark: [小历](https://itunes.apple.com/cn/app/id1031088612)：日历扩展小组件 - [更多介绍](https://sspai.com/post/35440)
-- :white_check_mark: [小历 for Mac](https://itunes.apple.com/cn/app/id1114272557)：日历扩展小组件
-- :white_check_mark: [Pin](https://itunes.apple.com/cn/app/id1039643846)：剪贴板扩展工具，App Store 2016 年度应用 - [更多介绍](https://sspai.com/post/36484)
-- :white_check_mark: [Pin for Mac](https://itunes.apple.com/cn/app/id1092997957)：剪贴板扩展工具
+- :white_check_mark: [JSBox](https://itunes.apple.com/cn/app/id1312014438): 用 JavaScript 实现原生小工具 - [更多介绍](https://sspai.com/post/42361)
+- :white_check_mark: [TodayMind](https://itunes.apple.com/cn/app/id1207158665): 提醒事项扩展小组件 - [更多介绍](https://sspai.com/post/37669)
+- :white_check_mark: [小历](https://itunes.apple.com/cn/app/id1031088612): 日历扩展小组件 - [更多介绍](https://sspai.com/post/35440)
+- :white_check_mark: [小历 for Mac](https://itunes.apple.com/cn/app/id1114272557): 日历扩展小组件
+- :white_check_mark: [Pin](https://itunes.apple.com/cn/app/id1039643846): 剪贴板扩展工具，App Store 2016 年度应用 - [更多介绍](https://sspai.com/post/36484)
+- :white_check_mark: [Pin for Mac](https://itunes.apple.com/cn/app/id1092997957): 剪贴板扩展工具
 
 #### 张嘉夫 - [GitHub](https://github.com/josephchang10), [微博](https://weibo.com/2949394297)
-* :white_check_mark: [生词本](https://itunes.apple.com/cn/app/生词本-智能背诵提醒/id1120027237?mt=8)：生词本 - 智能背诵提醒，让你记住所有查过的单词 - [更多介绍](https://itunes.apple.com/cn/app/生词本-智能背诵提醒/id1120027237?mt=8)
+* :white_check_mark: [生词本](https://itunes.apple.com/cn/app/生词本-智能背诵提醒/id1120027237?mt=8): 生词本 - 智能背诵提醒，让你记住所有查过的单词 - [更多介绍](https://itunes.apple.com/cn/app/生词本-智能背诵提醒/id1120027237?mt=8)
 
 #### nicejade - [GitHub](https://github.com/nicejade/), [博客](https://jeffjade.com)
 - :white_check_mark: [倾城之链](https://nicelinks.site/):  旨在云集全球优秀网站，方便你我探索互联网中更广阔的世界 - [更多介绍](https://jeffjade.com/2017/12/31/136-talk-about-nicelinks-site/)
 
 #### wizyoung - [GitHub](https://github.com/wizyoung)
-* :white_check_mark: [googletranslate.popclipext](https://github.com/wizyoung/googletranslate.popclipext)：一个 macOS 上的谷歌翻译 PopClip 扩展 - [更多介绍](https://github.com/wizyoung/googletranslate.popclipext)
+* :white_check_mark: [googletranslate.popclipext](https://github.com/wizyoung/googletranslate.popclipext): 一个 macOS 上的谷歌翻译 PopClip 扩展 - [更多介绍](https://github.com/wizyoung/googletranslate.popclipext)
 
 #### LiuYue - [GitHub](https://github.com/hangxingliu)
-* :white_check_mark: [steam-key-online-redeem](https://steamis.me)：Steam 游戏兑换码在线批量激活 - [更多介绍](https://github.com/hangxingliu/steam-key-online-redeem)
+* :white_check_mark: [steam-key-online-redeem](https://steamis.me): Steam 游戏兑换码在线批量激活 - [更多介绍](https://github.com/hangxingliu/steam-key-online-redeem)
 
 #### ApacheCN - [博客](http://www.apachecn.org/), [Github](https://github.com/apachecn)
-* :white_check_mark: [MLIA](http://ml.apachecn.org/mlia/)：Machine Learning course
+* :white_check_mark: [MLIA](http://ml.apachecn.org/mlia/): Machine Learning course
 
 #### Easy - [微博](https://weibo.com/easy), [Github](https://github.com/easychen)
-* :white_check_mark:[冷熊简历](http://cv.ftqq.com/)：在线 Markdown 简历工具，支持实时预览，一键 PDF。含常用片段，内容自动保存
-* :white_check_mark:[一键代币](https://token.ftqq.com)：1 分钟免费发布你自己的加密货币，支持自动发币
+* :white_check_mark:[冷熊简历](http://cv.ftqq.com/): 在线 Markdown 简历工具，支持实时预览，一键 PDF。含常用片段，内容自动保存
+* :white_check_mark:[一键代币](https://token.ftqq.com): 1 分钟免费发布你自己的加密货币，支持自动发币
 
 #### SCLeo - [GitHub](https://github.com/SCLeoX)
-* :white_check_mark: [pattern-finder](https://www.minegeck.net/lab/pf)：a smart(-stupid-) pattern-finding program - [更多介绍](https://github.com/SCLeoX/pattern-finder)
-* :white_check_mark: [Reload-Failure](https://scleox.github.io/Reload-Failure/index.html)：一个完全用 2d canvas 实现的伪 3D 躲避游戏 - [更多介绍](https://github.com/SCLeoX/Reload-Failure)
+* :white_check_mark: [pattern-finder](https://www.minegeck.net/lab/pf): a smart(-stupid-) pattern-finding program - [更多介绍](https://github.com/SCLeoX/pattern-finder)
+* :white_check_mark: [Reload-Failure](https://scleox.github.io/Reload-Failure/index.html): 一个完全用 2d canvas 实现的伪 3D 躲避游戏 - [更多介绍](https://github.com/SCLeoX/Reload-Failure)
 
 ### 2018年3月19号添加
 ---
 
 #### Molunerfinn - [GitHub](https://github.com/Molunerfinn)
-* :white_check_mark: [PicGo](https://molunerfinn.com/PicGo)：跨平台的图床图片上传工具 - [更多介绍](https://github.com/Molunerfinn/PicGo)
-* :white_check_mark: [node-github-profile-summary](https://gh-profile-summary.teamsz.xyz)：漂亮地生成你的GitHub总结的网站 - [更多介绍](https://github.com/Molunerfinn/node-github-profile-summary)
+* :white_check_mark: [PicGo](https://molunerfinn.com/PicGo): 跨平台的图床图片上传工具 - [更多介绍](https://github.com/Molunerfinn/PicGo)
+* :white_check_mark: [node-github-profile-summary](https://gh-profile-summary.teamsz.xyz): 漂亮地生成你的GitHub总结的网站 - [更多介绍](https://github.com/Molunerfinn/node-github-profile-summary)
 
 #### xu42 - [GitHub](http://github.com/xu42)
-* :white_check_mark: [qrcode-chrome](https://chrome.google.com/webstore/detail/qr-code-generation/imabbihlfpmlpobbfhmliilagnjeoija)：生成当前页面二维码的极简 Chrome 插件 - [更多介绍](https://github.com/xu42/qrcode-chrome)
-* :white_check_mark: [个人即时收款方案](https://pay.xu42.cn/)：个人可用的即时收款解决方案 - [更多介绍](https://github.com/xu42/pay)
+* :white_check_mark: [qrcode-chrome](https://chrome.google.com/webstore/detail/qr-code-generation/imabbihlfpmlpobbfhmliilagnjeoija): 生成当前页面二维码的极简 Chrome 插件 - [更多介绍](https://github.com/xu42/qrcode-chrome)
+* :white_check_mark: [个人即时收款方案](https://pay.xu42.cn/): 个人可用的即时收款解决方案 - [更多介绍](https://github.com/xu42/pay)
 
 #### kujian - [博客](http://caibaojian.com/), [Github](http://github.com/kujian)
-* :white_check_mark: [码农头条](http://hao.caibaojian.com)：每日自动抓取开发者文章并推荐 - [更多介绍](http://hao.caibaojian.com/about)
-* :white_check_mark: [GitHub热榜](http://news.caibaojian.com)：每日自动抓取 Github 前端热门项目并推荐
+* :white_check_mark: [码农头条](http://hao.caibaojian.com): 每日自动抓取开发者文章并推荐 - [更多介绍](http://hao.caibaojian.com/about)
+* :white_check_mark: [GitHub热榜](http://news.caibaojian.com): 每日自动抓取 Github 前端热门项目并推荐
 
 #### Jack Cherng - [GitHub](https://github.com/jfcherng)
-* :white_check_mark: [繁化姬](https://zhconvert.org)：一个强大的「繁简转换」与「本地化」工具 - [更多介绍](https://docs.zhconvert.org)
+* :white_check_mark: [繁化姬](https://zhconvert.org): 一个强大的「繁简转换」与「本地化」工具 - [更多介绍](https://docs.zhconvert.org)
 
 #### biezhi - [GitHub](https://github.com/biezhi)
-* :white_check_mark: [Findor](https://findor.me/)：分享你的个人社交信息
-* :white_check_mark: [开发者秘籍](https://dev-cheats.com/)：系统的开发者指南、教程
+* :white_check_mark: [Findor](https://findor.me/): 分享你的个人社交信息
+* :white_check_mark: [开发者秘籍](https://dev-cheats.com/): 系统的开发者指南、教程
 
 #### Caldis - [GitHub](https://github.com/Caldis)
-* :white_check_mark: [Mos](http://mos.u2sk.com/)：一个在 MacOS 上平滑鼠标滚动效果与单独设置滚动方向的小工具 - [更多介绍](https://github.com/Caldis/Mos)
+* :white_check_mark: [Mos](http://mos.u2sk.com/): 一个在 MacOS 上平滑鼠标滚动效果与单独设置滚动方向的小工具 - [更多介绍](https://github.com/Caldis/Mos)
 
 #### neal1991 - [GitHub](https://github.com/neal1991)
-* :white_check_mark: [上海地铁线路图](https://neal1991.github.io/subway-shanghai)：上海地铁线路图，包括站点时刻表信息，卫生间信息，出入口信息，无障碍电梯信息
-* :white_check_mark: [七牛云图床](https://chrome.google.com/webstore/detail/%E4%B8%83%E7%89%9B%E4%BA%91%E5%9B%BE%E5%BA%8A/fmpbbmjlniogoldpglopponaibclkjdg?utm_source=chrome-ntp-icon)：基于七牛云存储对象实现的私有图床 - [更多介绍](https://segmentfault.com/a/1190000013374209)
-* :white_check_mark: [export-to-markdown](https://chrome.google.com/webstore/detail/export-to-markdown/dodkihcbgpjblncjahodbnlgkkflliim?utm_source=chrome-ntp-icon)：将博文转化成 Markdown 格式，目前支持 Medium 和 elastic 官博 - [更多介绍](https://segmentfault.com/a/1190000011324821)
-* :white_check_mark: [去哪拍照片](http://ozfo4jjxb.bkt.clouddn.com/gh_900fd73a1fd0_258.jpg)：微信小程序，主要是上海市落户拍照地点，包括免费和收费两种
+* :white_check_mark: [上海地铁线路图](https://neal1991.github.io/subway-shanghai): 上海地铁线路图，包括站点时刻表信息，卫生间信息，出入口信息，无障碍电梯信息
+* :white_check_mark: [七牛云图床](https://chrome.google.com/webstore/detail/%E4%B8%83%E7%89%9B%E4%BA%91%E5%9B%BE%E5%BA%8A/fmpbbmjlniogoldpglopponaibclkjdg?utm_source=chrome-ntp-icon): 基于七牛云存储对象实现的私有图床 - [更多介绍](https://segmentfault.com/a/1190000013374209)
+* :white_check_mark: [export-to-markdown](https://chrome.google.com/webstore/detail/export-to-markdown/dodkihcbgpjblncjahodbnlgkkflliim?utm_source=chrome-ntp-icon): 将博文转化成 Markdown 格式，目前支持 Medium 和 elastic 官博 - [更多介绍](https://segmentfault.com/a/1190000011324821)
+* :white_check_mark: [去哪拍照片](http://ozfo4jjxb.bkt.clouddn.com/gh_900fd73a1fd0_258.jpg): 微信小程序，主要是上海市落户拍照地点，包括免费和收费两种
 
 #### GitIssue - [GitHub](https://github.com/git-issue)
 * :white_check_mark: [GitIssue](https://gitissue.com): Github Issue blog platform - [更多介绍](https://gitissue.com/about)
 
 
 #### Haocold - [GitHub](https://github.com/xjh093)
-* :white_check_mark: [X_Wubi](https://itunes.apple.com/cn/app/X_Wubi/id1122043433)：简洁、轻盈，在游戏中学五笔
+* :white_check_mark: [X_Wubi](https://itunes.apple.com/cn/app/X_Wubi/id1122043433): 简洁、轻盈，在游戏中学五笔
 
 #### LiangLuDev - [GitHub](https://github.com/LiangLuDev/)
-* :clock8: [微Yue](https://github.com/LiangLuDev/WeYueReader)：Android e-book reading App
+* :clock8: [微Yue](https://github.com/LiangLuDev/WeYueReader): Android e-book reading App
 
 #### jkpang - [GitHub](https://github.com/jkpang)
-* :white_check_mark: [PPHub](https://itunes.apple.com/cn/app/PPHub%20For%20GitHub/id1314212521?mt=8)：一个简洁漂亮的 GitHub 客户端 - [更多介绍](https://github.com/jkpang/PPHub-Feedback)
+* :white_check_mark: [PPHub](https://itunes.apple.com/cn/app/PPHub%20For%20GitHub/id1314212521?mt=8): 一个简洁漂亮的 GitHub 客户端 - [更多介绍](https://github.com/jkpang/PPHub-Feedback)
 
 #### gaolinjie - [GitHub](https://github.com/gaolinjie)
-* :white_check_mark: [Love2.io](https://love2.io/)：一个优雅的开源技术文档分享平台 - [更多介绍](https://love2.io/@love2io/doc/hello-love2io)
+* :white_check_mark: [Love2.io](https://love2.io/): 一个优雅的开源技术文档分享平台 - [更多介绍](https://love2.io/@love2io/doc/hello-love2io)
 
 #### Magic-fe - [GitHub](https://github.com/magic-FE)
-* :white_check_mark: [翻译侠](https://chrome.google.com/webstore/detail/translate-man/fapgabkkfcaejckbfmfcdgnfefbmlion)：一款超棒的翻译插件（支持 Chrome + Firefox） - [更多介绍](https://github.com/magic-FE/translate-man)
+* :white_check_mark: [翻译侠](https://chrome.google.com/webstore/detail/translate-man/fapgabkkfcaejckbfmfcdgnfefbmlion): 一款超棒的翻译插件（支持 Chrome + Firefox） - [更多介绍](https://github.com/magic-FE/translate-man)
 
 #### Windson - [GitHub](https://github.com/Windsooon)
-* :white_check_mark: [Channelshunt](https://www.channelshunt.com/)：YouTube 频道推荐站
-* :white_check_mark: [Thank you, Open source](https://www.thankyouopensource.com/)：给开源项目的感谢信
-* :white_check_mark: [OpenSource Jobs](https://www.osjobs.net/)：根据开源项目的贡献推荐工作
-* :clock8: [EngineGo](https://www.enginego.org/)：计算机基础教程
+* :white_check_mark: [Channelshunt](https://www.channelshunt.com/): YouTube 频道推荐站
+* :white_check_mark: [Thank you, Open source](https://www.thankyouopensource.com/): 给开源项目的感谢信
+* :white_check_mark: [OpenSource Jobs](https://www.osjobs.net/): 根据开源项目的贡献推荐工作
+* :clock8: [EngineGo](https://www.enginego.org/): 计算机基础教程
 
 
 #### yaoleifly - [GitHub](https://github.com/yaoleifly)
-* :white_check_mark: [电子书支援计划](https://www.ebooksplan.org/)：一个以数字资源为核心的自我学习社群 
-* :white_check_mark: [扫地僧的橱柜](https://www.ebooksplan.club/)：支持 Kindle 内置浏览器的资源站
+* :white_check_mark: [电子书支援计划](https://www.ebooksplan.org/): 一个以数字资源为核心的自我学习社群 
+* :white_check_mark: [扫地僧的橱柜](https://www.ebooksplan.club/): 支持 Kindle 内置浏览器的资源站
 
 #### mw2c - [GitHub](https://github.com/mw2c)
-* :white_check_mark: [Guitar Tabs Search](http://gtpso.com/)：An App and website to share, search and play guitar tabs.
-* :white_check_mark: [Tab PlayAlong](https://playalong.gtpso.com/)：An iOS App that allows you to connect your guitar to your iOS devices and play along with guitar tabs using amplifier and effects
+* :white_check_mark: [Guitar Tabs Search](http://gtpso.com/): An App and website to share, search and play guitar tabs.
+* :white_check_mark: [Tab PlayAlong](https://playalong.gtpso.com/): An iOS App that allows you to connect your guitar to your iOS devices and play along with guitar tabs using amplifier and effects
 
 #### 小贝 - [GitHub](https://github.com/easyhappy/)
-* :white_check_mark: [美股指南](https://investguider.com/)：美股、港股投资指南
+* :white_check_mark: [美股指南](https://investguider.com/): 美股、港股投资指南
 
 #### H1ac0k - [博客](http://xrong.net)
-* :white_check_mark: [斗图啦](https://www.doutula.com)：斗图装逼必备
+* :white_check_mark: [斗图啦](https://www.doutula.com): 斗图装逼必备
 
 #### Tolecen - [博客](https://xinle.co/)
-* :white_check_mark: [白描](https://itunes.apple.com/cn/app/id1249901692)：高效的文字识别与翻译软件 - [更多介绍](https://sspai.com/post/42065)
-* :white_check_mark: [西江月](https://itunes.apple.com/cn/app/id1084924739)：遇见传统诗词之美 - [更多介绍](https://sspai.com/post/38786)
-* :white_check_mark: [天天成语](https://itunes.apple.com/cn/app/id843601091)：简洁方便的离线成语词典 - [更多介绍](https://xinle.co/2016/05/26/chengyu/)
+* :white_check_mark: [白描](https://itunes.apple.com/cn/app/id1249901692): 高效的文字识别与翻译软件 - [更多介绍](https://sspai.com/post/42065)
+* :white_check_mark: [西江月](https://itunes.apple.com/cn/app/id1084924739): 遇见传统诗词之美 - [更多介绍](https://sspai.com/post/38786)
+* :white_check_mark: [天天成语](https://itunes.apple.com/cn/app/id843601091): 简洁方便的离线成语词典 - [更多介绍](https://xinle.co/2016/05/26/chengyu/)
 
 #### textproofreading - [GitHub](https://github.com/textproofreading/)
-* :white_check_mark: [中文错别字纠错校对系统](http://www.CuoBieZi.net/)： 一个可以在线检测中文错别字的工具
+* :white_check_mark: [中文错别字纠错校对系统](http://www.CuoBieZi.net/):  一个可以在线检测中文错别字的工具
 
 #### hanks - [GitHub](https://github.com/hanks-zyh)
-* :white_check_mark: [便签](https://www.coolapk.com/apk/xyz.hanks.note)：体积不足 2M，功能却全面到令人惊喜的 Android 便签应用 - [更多介绍](https://sspai.com/post/41323)
-* :white_check_mark: [氢应用](https://www.coolapk.com/apk/pub.hydrogen.android)：一款 Android 插件容器应用
+* :white_check_mark: [便签](https://www.coolapk.com/apk/xyz.hanks.note): 体积不足 2M，功能却全面到令人惊喜的 Android 便签应用 - [更多介绍](https://sspai.com/post/41323)
+* :white_check_mark: [氢应用](https://www.coolapk.com/apk/pub.hydrogen.android): 一款 Android 插件容器应用
 
 #### CoderDwang - [GitHub](https://github.com/CoderDwang)
-* :clock8: [MoreiTunesConnect_iOS](https://github.com/CoderDwang/MoreiTunesConnect_iOS)：允许多开的非苹果官方的 App 审核状态查询
+* :clock8: [MoreiTunesConnect_iOS](https://github.com/CoderDwang/MoreiTunesConnect_iOS): 允许多开的非苹果官方的 App 审核状态查询
 
 #### coderyi - [GitHub](https://github.com/coderyi)
-* :white_check_mark: [Monkey for Github](https://itunes.apple.com/cn/app/monkey-for-github/id1003765407)：以 GitHub 排名为主的 GitHub App，支持iOS/Android - [更多介绍](https://github.com/coderyi/Monkey)
+* :white_check_mark: [Monkey for Github](https://itunes.apple.com/cn/app/monkey-for-github/id1003765407): 以 GitHub 排名为主的 GitHub App，支持iOS/Android - [更多介绍](https://github.com/coderyi/Monkey)
 
 #### bugulink - [GitHub](https://github.com/bugulink)
-* :white_check_mark: [BuguLink](https://bugu.link)：一个快速安全的文件分享网站
+* :white_check_mark: [BuguLink](https://bugu.link): 一个快速安全的文件分享网站
 
 #### Larry - [码力全开科技工作室](http://maliquankai.com)
-* :white_check_mark: [奇点日报](https://itunes.apple.com/us/app/wa-wa-yu-jian-hao-yin-le/id1223916908?l=zh&ls=1&mt=8)：高逼格程序员开发者技术分享平台
-* :white_check_mark: [破壳日](https://itunes.apple.com/us/app/破壳日/id1267213085?l=zh&ls=1&mt=8)：精美的生日 · 节日 · 纪念日礼物提醒工具
-* :white_check_mark: [壹日程](https://itunes.apple.com/us/app/壹日程-专注任务管理和待办计划提醒/id1251547470?l=zh&ls=1&mt=8)：专注任务管理和待办计划提醒
-* :white_check_mark: [心动屋](https://itunes.apple.com/us/app/心动屋-发现令你心动的好物/id1234003952?l=zh&ls=1&mt=8)：发现令你心动的好物
-* :white_check_mark: [口袋密码](https://itunes.apple.com/us/app/口袋密码-安全简洁的账号管家/id1256288406?l=zh&ls=1&mt=8)：安全简洁的账号管家
-* :white_check_mark: [拾光记](https://itunes.apple.com/us/app/拾光记-拾起你走过的时光/id1247124599?l=zh&ls=1&mt=8)：拾起你走过的时光
+* :white_check_mark: [奇点日报](https://itunes.apple.com/us/app/wa-wa-yu-jian-hao-yin-le/id1223916908?l=zh&ls=1&mt=8): 高逼格程序员开发者技术分享平台
+* :white_check_mark: [破壳日](https://itunes.apple.com/us/app/破壳日/id1267213085?l=zh&ls=1&mt=8): 精美的生日 · 节日 · 纪念日礼物提醒工具
+* :white_check_mark: [壹日程](https://itunes.apple.com/us/app/壹日程-专注任务管理和待办计划提醒/id1251547470?l=zh&ls=1&mt=8): 专注任务管理和待办计划提醒
+* :white_check_mark: [心动屋](https://itunes.apple.com/us/app/心动屋-发现令你心动的好物/id1234003952?l=zh&ls=1&mt=8): 发现令你心动的好物
+* :white_check_mark: [口袋密码](https://itunes.apple.com/us/app/口袋密码-安全简洁的账号管家/id1256288406?l=zh&ls=1&mt=8): 安全简洁的账号管家
+* :white_check_mark: [拾光记](https://itunes.apple.com/us/app/拾光记-拾起你走过的时光/id1247124599?l=zh&ls=1&mt=8): 拾起你走过的时光
 
 #### lfb-cd - [Github](https://github.com/lfb-cd)
-* :white_check_mark: [Net](https://itunes.apple.com/app/id1288011873)：网速展示流量统计工具
-* :white_check_mark: [Net-Lite](https://itunes.apple.com/app/id1109807177)：精简版网速展示流量统计工具
-* :white_check_mark: [晴天见](https://itunes.apple.com/app/id1231863233)：极简天气应用
+* :white_check_mark: [Net](https://itunes.apple.com/app/id1288011873): 网速展示流量统计工具
+* :white_check_mark: [Net-Lite](https://itunes.apple.com/app/id1109807177): 精简版网速展示流量统计工具
+* :white_check_mark: [晴天见](https://itunes.apple.com/app/id1231863233): 极简天气应用
 * :white_check_mark: [Reminder](https://itunes.apple.com/app/id1258508583): 只有 1.5MB 的极简备忘 APP
 
 #### cllgeek - [GitHub](https://github.com/cllgeek)
-* :white_check_mark: [极客教程](https://www.geekjc.com)：一个提供学习编程资料的网站
+* :white_check_mark: [极客教程](https://www.geekjc.com): 一个提供学习编程资料的网站
 
 #### CarGuo - [GitHub](https://github.com/CarGuo)
-* :white_check_mark: [GSYGithubAPP](https://www.pgyer.com/GSYGithubApp)：高质量的 Github 客户端 - [更多介绍](https://github.com/CarGuo/GSYGithubAPP)
+* :white_check_mark: [GSYGithubAPP](https://www.pgyer.com/GSYGithubApp): 高质量的 Github 客户端 - [更多介绍](https://github.com/CarGuo/GSYGithubAPP)
 
 #### biqinglin - [GitHub](https://github.com/biqinglin)
-* :white_check_mark: [小私密](https://link.jianshu.com/?t=https://itunes.apple.com/us/app/小私密-匿名分享你的小私密/id1249902405?l=zh&ls=1&mt=8)：小私密，一款匿名分享你的小私密的轻社交应用 - [更多介绍](https://www.jianshu.com/p/4582c6f914eb)
+* :white_check_mark: [小私密](https://link.jianshu.com/?t=https://itunes.apple.com/us/app/小私密-匿名分享你的小私密/id1249902405?l=zh&ls=1&mt=8): 小私密，一款匿名分享你的小私密的轻社交应用 - [更多介绍](https://www.jianshu.com/p/4582c6f914eb)
 * :white_check_mark:  [App Store 全部作品](https://itunes.apple.com/cn/developer/qinglin-bi/id1228179246?l=en&mt=8)
 
 #### Anynices
-* :white_check_mark: [拼红包](https://www.pinghongbao.com)：外卖红包实时分享
+* :white_check_mark: [拼红包](https://www.pinghongbao.com): 外卖红包实时分享
 
 #### sheepkx - [GitHub](https://github.com/sheepkx)
-* :white_check_mark: [闪念ToDo](https://www.coolapk.com/apk/com.kdfly.todo)：ToDo 计划管理App
+* :white_check_mark: [闪念ToDo](https://www.coolapk.com/apk/com.kdfly.todo): ToDo 计划管理App
 
 #### jiangboLee - [GitHub](https://github.com/jiangboLee)
-* :white_check_mark: [Ptoo](https://itunes.apple.com/us/app/ptoo/id1219224872?mt=8)：一款美图软件 - [更多介绍](https://github.com/jiangboLee/huangpian)
-* :white_check_mark: [即时天气](https://github.com/jiangboLee/WeatherWX)：一款天气预报小程序~
+* :white_check_mark: [Ptoo](https://itunes.apple.com/us/app/ptoo/id1219224872?mt=8): 一款美图软件 - [更多介绍](https://github.com/jiangboLee/huangpian)
+* :white_check_mark: [即时天气](https://github.com/jiangboLee/WeatherWX): 一款天气预报小程序~
 
 #### MORECATS - [GitHub](https://github.com/MORECATS)
-* :white_check_mark: [视觉图表](https://itunes.apple.com/cn/app/id1090006424)：适用于 iPhone & iPad 的图表制作应用
-* :white_check_mark: [标注图像+](https://itunes.apple.com/cn/app/id1227197910)：高效快捷地标注图像，长图，拼图，二维码一应俱全
-* :white_check_mark: [课程表](https://itunes.apple.com/cn/app/id1219202104)：一周课程表 & 艾宾浩斯遗忘曲线计划表
-* :white_check_mark: [今日美图](https://itunes.apple.com/cn/app/id1195400858)：获取今日 Bing 美图，每日新视野
-* :white_check_mark: [网速查看+](https://itunes.apple.com/cn/app/id1289105991)：在 iPhone & iPad 通知小部件上查看实时网络上下行速度
-* :white_check_mark: [取色器+](https://itunes.apple.com/cn/app/id1326506149)：像素级图像取色 & 色彩收集
-* :white_check_mark: [短信过滤+](https://itunes.apple.com/cn/app/id1314415052)：基于 iOS 11 新特性的垃圾短信过滤应用
+* :white_check_mark: [视觉图表](https://itunes.apple.com/cn/app/id1090006424): 适用于 iPhone & iPad 的图表制作应用
+* :white_check_mark: [标注图像+](https://itunes.apple.com/cn/app/id1227197910): 高效快捷地标注图像，长图，拼图，二维码一应俱全
+* :white_check_mark: [课程表](https://itunes.apple.com/cn/app/id1219202104): 一周课程表 & 艾宾浩斯遗忘曲线计划表
+* :white_check_mark: [今日美图](https://itunes.apple.com/cn/app/id1195400858): 获取今日 Bing 美图，每日新视野
+* :white_check_mark: [网速查看+](https://itunes.apple.com/cn/app/id1289105991): 在 iPhone & iPad 通知小部件上查看实时网络上下行速度
+* :white_check_mark: [取色器+](https://itunes.apple.com/cn/app/id1326506149): 像素级图像取色 & 色彩收集
+* :white_check_mark: [短信过滤+](https://itunes.apple.com/cn/app/id1314415052): 基于 iOS 11 新特性的垃圾短信过滤应用
 
 #### Jocs - [GitHub](https://github.com/Jocs)
-* :white_check_mark:  [Mark Text](https://marktext.github.io/website/)：所输及所见的 Markdown 编辑器，支持源码模式、焦点模式、打字机模式 - [更多介绍](https://github.com/marktext/marktext/)
+* :white_check_mark:  [Mark Text](https://marktext.github.io/website/): 所输及所见的 Markdown 编辑器，支持源码模式、焦点模式、打字机模式 - [更多介绍](https://github.com/marktext/marktext/)
 
 #### 滑滑鸡 - [GitHub](https://github.com/songkuixi)
-* :white_check_mark: [单语](https://itunes.apple.com/cn/app/单语-日语生词本-日语单词-日语学习/id1086636706)：一个日语单词本应用
-* :white_check_mark: [APOD](https://itunes.apple.com/us/app/apod/id1173315594)：一个每日天文一图客户端
-* :white_check_mark: [今日打卡](https://itunes.apple.com/cn/app/keeping-任务管理利器-打卡习惯养成/id1197272196)：一个小巧的日程管理打卡应用 - [更多介绍](https://github.com/songkuixi/Keeping)
-* :white_check_mark: [TouchBrickout](https://itunes.apple.com/cn/app/touchbrickout/id1314804894)：一款在 Mac 上用键盘或者 Touch Bar 进行打砖块的游戏 - [更多介绍](https://github.com/songkuixi/TouchBreakout)
+* :white_check_mark: [单语](https://itunes.apple.com/cn/app/单语-日语生词本-日语单词-日语学习/id1086636706): 一个日语单词本应用
+* :white_check_mark: [APOD](https://itunes.apple.com/us/app/apod/id1173315594): 一个每日天文一图客户端
+* :white_check_mark: [今日打卡](https://itunes.apple.com/cn/app/keeping-任务管理利器-打卡习惯养成/id1197272196): 一个小巧的日程管理打卡应用 - [更多介绍](https://github.com/songkuixi/Keeping)
+* :white_check_mark: [TouchBrickout](https://itunes.apple.com/cn/app/touchbrickout/id1314804894): 一款在 Mac 上用键盘或者 Touch Bar 进行打砖块的游戏 - [更多介绍](https://github.com/songkuixi/TouchBreakout)
 
 #### haozes - [GitHub](https://github.com/haozes)
-* :white_check_mark: [YaoYao](https://itunes.apple.com/cn/app/id1179393901/)：Apple Watch 跳绳计数应用 - [更多介绍](https://sspai.com/post/40103)
-* :white_check_mark: [DunDun](https://itunes.apple.com/cn/app/dundun-squats-counter/id1348285355?l=zh&ls=1&mt=8)：Apple Watch 深蹲计数应用 - [更多介绍](https://sspai.com/post/43319)
+* :white_check_mark: [YaoYao](https://itunes.apple.com/cn/app/id1179393901/): Apple Watch 跳绳计数应用 - [更多介绍](https://sspai.com/post/40103)
+* :white_check_mark: [DunDun](https://itunes.apple.com/cn/app/dundun-squats-counter/id1348285355?l=zh&ls=1&mt=8): Apple Watch 深蹲计数应用 - [更多介绍](https://sspai.com/post/43319)
 
 #### Tuluobo - [GitHub](https://github.com/Tuluobo)
-* :white_check_mark: [玩客钱包](https://itunes.apple.com/cn/app/%E7%8E%A9%E5%AE%A2%E9%92%B1%E5%8C%85/id1302778851)：迅雷玩客币（改名链克）的非官方查询管理钱包 APP - [更多介绍](https://github.com/Tuluobo/LKWallet) 
+* :white_check_mark: [玩客钱包](https://itunes.apple.com/cn/app/%E7%8E%A9%E5%AE%A2%E9%92%B1%E5%8C%85/id1302778851): 迅雷玩客币（改名链克）的非官方查询管理钱包 APP - [更多介绍](https://github.com/Tuluobo/LKWallet) 
 
 #### forecho - [GitHub](https://github.com/forecho)
 * :white_check_mark: [三立三](https://3li3.com/): 提供 Kindle 电子书和 iOS App 降价提醒和购买服务 - [更多介绍](http://blog.3li3.com/releases-v2/)
 
 #### JonyFang - [GitHub](https://github.com/JonyFang), [微博](http://weibo.com/u/3034766044),[Twitter](https://twitter.com/jony_chunfang)
 
-* :white_check_mark: [Shots 精简壁纸](https://shoots.coding.me/)：一款精简壁纸应用，最原本的方式，最简朴的体验，只为在你挑选壁纸时，给予小小的建议：）
-* :clock8: [Time Progress](https://github.com/TimeProgress)：让时间变成时间块，一块块清晰可见。在这里，可以让你看到时间的变化
+* :white_check_mark: [Shots 精简壁纸](https://shoots.coding.me/): 一款精简壁纸应用，最原本的方式，最简朴的体验，只为在你挑选壁纸时，给予小小的建议: ）
+* :clock8: [Time Progress](https://github.com/TimeProgress): 让时间变成时间块，一块块清晰可见。在这里，可以让你看到时间的变化
 
 #### oasisfeng - [GitHub](https://github.com/oasisfeng)
-* :white_check_mark: [绿色守护 (Greenify)](https://www.coolapk.com/apk/com.oasisfeng.greenify)：帮助甄别那些对系统性能和耗电有不良影响的程序，阻止它们 （省略原描述20字）
-* :white_check_mark: [岛 (Island)](https://www.coolapk.com/apk/com.oasisfeng.island)：提供：隔离应用，保护隐私、克隆应用，平行运行（省略原描述20字）等功能
+* :white_check_mark: [绿色守护 (Greenify)](https://www.coolapk.com/apk/com.oasisfeng.greenify): 帮助甄别那些对系统性能和耗电有不良影响的程序，阻止它们 （省略原描述20字）
+* :white_check_mark: [岛 (Island)](https://www.coolapk.com/apk/com.oasisfeng.island): 提供: 隔离应用，保护隐私、克隆应用，平行运行（省略原描述20字）等功能
 
 #### meowtec - [GitHub](https://github.com/meowtec/)
 - :white_check_mark: [Imagine](https://github.com/meowtec/Imagine): 一个跨平台的图片可视压缩 PC App
 
 #### ywwhack - [GitHub](https://github.com/ywwhack)
-* :white_check_mark: [aidou-electron](https://github.com/ywwhack/aidou-electron)：(Mac) 斗图神器 - 根据关键字搜索表情，一键复制
+* :white_check_mark: [aidou-electron](https://github.com/ywwhack/aidou-electron): (Mac) 斗图神器 - 根据关键字搜索表情，一键复制
 
 #### kinglisky - [GitHub](https://github.com/kinglisky)
-* :white_check_mark: [aidou](https://chrome.google.com/webstore/detail/aidou/kidfkhcacngpkgkagdmbkncecbnadajb?hl=zh-CN)： (Chrome 插件) 社区回帖 Code review 斗图插件，一键生成表情链接 - [了解更多](https://github.com/kinglisky/aidou)
+* :white_check_mark: [aidou](https://chrome.google.com/webstore/detail/aidou/kidfkhcacngpkgkagdmbkncecbnadajb?hl=zh-CN):  (Chrome 插件) 社区回帖 Code review 斗图插件，一键生成表情链接 - [了解更多](https://github.com/kinglisky/aidou)
 
 #### daniel - [微博](https://weibo.com/u/1749949233)
-* :white_check_mark: [煎蛋](https://play.google.com/store/apps/details?id=com.danielstudio.app.wowtu)：煎蛋 Android 客户端
+* :white_check_mark: [煎蛋](https://play.google.com/store/apps/details?id=com.danielstudio.app.wowtu): 煎蛋 Android 客户端
 
 #### tinyao - [GitHub](https://github.com/tinyao)
-* :white_check_mark: [有饭](https://fan.zico.im/)：一款白白的饭否 Android 客户端
+* :white_check_mark: [有饭](https://fan.zico.im/): 一款白白的饭否 Android 客户端
 
 
 ### 2018年3月18号添加
 ---
 
 #### 青杨 - [GitHub](https://github.com/HuQingyang)
-* :white_check_mark: [Luoo.qy](https://github.com/HuQingyang/Luoo.qy)：独立音乐社区[落网](http://www.luoo.net/)的第三方电脑客户端
-* :white_check_mark: [Page.qy](https://github.com/HuQingyang/Page.qy)：一款针对小白(~~懒人~~)的自动化管理、生成、部署个人博客的工具
+* :white_check_mark: [Luoo.qy](https://github.com/HuQingyang/Luoo.qy): 独立音乐社区[落网](http://www.luoo.net/)的第三方电脑客户端
+* :white_check_mark: [Page.qy](https://github.com/HuQingyang/Page.qy): 一款针对小白(~~懒人~~)的自动化管理、生成、部署个人博客的工具
 
 #### zomco - [GitHub](https://github.com/zomco)
-* :white_check_mark: [路几](http://www.ruki.pw)：分享精彩的行车记录仪视频
+* :white_check_mark: [路几](http://www.ruki.pw): 分享精彩的行车记录仪视频
 
 #### Akring - [GitHub](https://github.com/akring)
-* :white_check_mark: [Star Order for Mac/iOS](https://star-order.com/)：Mac/iOS 双平台的 GitHub Star 管理工具
+* :white_check_mark: [Star Order for Mac/iOS](https://star-order.com/): Mac/iOS 双平台的 GitHub Star 管理工具
 
 #### Jinya - [GitHub](https://github.com/JinyaX), [微博](https://weibo.com/934249787)
-* :white_check_mark: [短信卫士](https://itunes.apple.com/cn/app/%E7%9F%AD%E4%BF%A1%E5%8D%AB%E5%A3%AB/id1317407948?mt=8)：iOS 垃圾短信过滤工具（需要 iOS 11.0 或更高版本） 
-* :clock8: [Key Master]()：iOS 密码管理工具
+* :white_check_mark: [短信卫士](https://itunes.apple.com/cn/app/%E7%9F%AD%E4%BF%A1%E5%8D%AB%E5%A3%AB/id1317407948?mt=8): iOS 垃圾短信过滤工具（需要 iOS 11.0 或更高版本） 
+* :clock8: [Key Master](): iOS 密码管理工具
 
 #### Collider LI - [GitHub](https://github.com/lhc70000)
-* :white_check_mark: [IINA](https://github.com/lhc70000/iina)：一个现代的 macOS 媒体播放器
+* :white_check_mark: [IINA](https://github.com/lhc70000/iina): 一个现代的 macOS 媒体播放器
 
 #### lijianqiang12 - [博客](http://lijianqiang12.com)
-* :white_check_mark: [远离手机](http://www.offphone.net)：一个能将手机锁定一段时间的 App
+* :white_check_mark: [远离手机](http://www.offphone.net): 一个能将手机锁定一段时间的 App
 
 #### Jason - [博客](https://atjason.com/)
-* :white_check_mark: [Klib](https://itunes.apple.com/cn/app/id1196268448?mt=12)：Kindle、iBooks、多看标注与笔记管理 - [更多介绍](https://toolinbox.net/Klib/)
-* :white_check_mark: [iText](https://itunes.apple.com/cn/app/id1314980676?mt=12)：从图片中识别文字的 OCR 工具 - [更多介绍](https://toolinbox.net/iText/)
-* :white_check_mark: [iPic](https://itunes.apple.com/cn/app/id1101244278?mt=12)：图床工具、Markdown 插图助手，支持微博、七牛、又拍、阿里云等图床 - [更多介绍](https://toolinbox.net/iPic/)
-* :white_check_mark: [iPaste](https://itunes.apple.com/cn/app/id1056935452?mt=12)：给效率人士开发的剪切板工具，macOS & iOS 双平台 - [更多介绍](https://toolinbox.net/iPaste/)
-* :white_check_mark: [iHosts](https://itunes.apple.com/cn/app/id1102004240?mt=12)：唯一上架 Mac App Store 的 /etc/hosts 编辑工具 - [更多介绍](https://toolinbox.net/iHosts/)
+* :white_check_mark: [Klib](https://itunes.apple.com/cn/app/id1196268448?mt=12): Kindle、iBooks、多看标注与笔记管理 - [更多介绍](https://toolinbox.net/Klib/)
+* :white_check_mark: [iText](https://itunes.apple.com/cn/app/id1314980676?mt=12): 从图片中识别文字的 OCR 工具 - [更多介绍](https://toolinbox.net/iText/)
+* :white_check_mark: [iPic](https://itunes.apple.com/cn/app/id1101244278?mt=12): 图床工具、Markdown 插图助手，支持微博、七牛、又拍、阿里云等图床 - [更多介绍](https://toolinbox.net/iPic/)
+* :white_check_mark: [iPaste](https://itunes.apple.com/cn/app/id1056935452?mt=12): 给效率人士开发的剪切板工具，macOS & iOS 双平台 - [更多介绍](https://toolinbox.net/iPaste/)
+* :white_check_mark: [iHosts](https://itunes.apple.com/cn/app/id1102004240?mt=12): 唯一上架 Mac App Store 的 /etc/hosts 编辑工具 - [更多介绍](https://toolinbox.net/iHosts/)
 
 
 #### 潇涧 - [GitHub](https://github.com/hujiaweibujidao)
-* :white_check_mark: [诗鲸](https://tab.leancloud.cn/1/stats/track/2lkBXY)：诗鲸是一款简洁而呆萌的诗词学习应用 - [更多介绍](http://zuimeia.com/app/5772/?platform=2)
-* :white_check_mark: [干货集中营Mac客户端](https://github.com/hujiaweibujidao/Gank-for-Mac)：『Gank for Mac』 可能是唯一的干货集中营 Mac 客户端
+* :white_check_mark: [诗鲸](https://tab.leancloud.cn/1/stats/track/2lkBXY): 诗鲸是一款简洁而呆萌的诗词学习应用 - [更多介绍](http://zuimeia.com/app/5772/?platform=2)
+* :white_check_mark: [干货集中营Mac客户端](https://github.com/hujiaweibujidao/Gank-for-Mac): 『Gank for Mac』 可能是唯一的干货集中营 Mac 客户端
 
 #### tomasy - [GitHub](https://github.com/solobat)
-* :white_check_mark: [Steward](https://github.com/solobat/Steward)：Chrome 上类 Alfred / Wox 命令启动器扩展
-* :white_check_mark: [单词小卡片](https://github.com/solobat/wordcard)：单词查询、例句收集、单词记忆于一体的浏览器扩展，支持 Chrome / Firefox
+* :white_check_mark: [Steward](https://github.com/solobat/Steward): Chrome 上类 Alfred / Wox 命令启动器扩展
+* :white_check_mark: [单词小卡片](https://github.com/solobat/wordcard): 单词查询、例句收集、单词记忆于一体的浏览器扩展，支持 Chrome / Firefox
 
 #### NextStack - [GitHub](https://github.com/safe-dog), [博客](https://blog.nextstack.xyz)
-* :white_check_mark: [下一栈](https://nextstack.xyz)：把你的博客网站制作成 APP 进行更爽阅读浏览
+* :white_check_mark: [下一栈](https://nextstack.xyz): 把你的博客网站制作成 APP 进行更爽阅读浏览
 
 #### zyx0814 - [GitHub](https://github.com/zyx0814/dzzoffice)
-* :white_check_mark: [DzzOffice](http://dzzoffice.com)：类似 Office365, Google 企业应用套件的开源私有方案
+* :white_check_mark: [DzzOffice](http://dzzoffice.com): 类似 Office365, Google 企业应用套件的开源私有方案
 
 #### ming
-* :white_check_mark: [京价保](https://jjb.im/)：京价保是一个帮助你自动申请京东价格保护，顺便帮你签到领券，自动领取返利的 Chrome 拓展 - [更多介绍](https://github.com/sunoj/jjb)
+* :white_check_mark: [京价保](https://jjb.im/): 京价保是一个帮助你自动申请京东价格保护，顺便帮你签到领券，自动领取返利的 Chrome 拓展 - [更多介绍](https://github.com/sunoj/jjb)
 
 #### 叶大侠 - [GitHub](https://github.com/YeDaxia)
-* :white_check_mark: [声音笔记+](http://www.wandoujia.com/apps/com.cmajor.musicnote)：一个人，也可以像一支乐队一样练琴 - [更多介绍](http://yedaxia.me/How-To-Play-Music-Like-A-Bank/)
-* :white_check_mark: [为你搜谱](http://sopu.52cmajor.com/)：应该是国内最全的乐谱搜索引擎了
+* :white_check_mark: [声音笔记+](http://www.wandoujia.com/apps/com.cmajor.musicnote): 一个人，也可以像一支乐队一样练琴 - [更多介绍](http://yedaxia.me/How-To-Play-Music-Like-A-Bank/)
+* :white_check_mark: [为你搜谱](http://sopu.52cmajor.com/): 应该是国内最全的乐谱搜索引擎了
 
 ####  mclxly - [GitHub](https://github.com/mclxly)
-* :white_check_mark: [我旁](https://3kmq.com/)：这是一个分享 / 发现周边生活资讯的社区
+* :white_check_mark: [我旁](https://3kmq.com/): 这是一个分享 / 发现周边生活资讯的社区
 
 #### @drakeet - [GitHub](https://github.com/drakeet)
-- :white_check_mark: [纯纯写作](https://sspai.com/post/43650)：绝不丢失文本编辑器 - [更多介绍](https://sspai.com/post/43650)
+- :white_check_mark: [纯纯写作](https://sspai.com/post/43650): 绝不丢失文本编辑器 - [更多介绍](https://sspai.com/post/43650)
 
 #### Soledad - [GitHub](https://github.com/caiyue1993), [微博](https://weibo.com/caiyue233/)
-* :white_check_mark: [Lazy K](https://itunes.apple.com/cn/app/lazy-k/id1348224910?mt=8)：不想聊天的敷衍“输入法” - [更多介绍](https://sspai.com/post/43386)
-* :white_check_mark: [小目标](https://itunes.apple.com/cn/app/%E5%B0%8F%E7%9B%AE%E6%A0%87-%E9%87%8F%E5%8C%96%E4%BD%A0%E7%9A%84%E8%BF%9B%E6%AD%A5/id1215312957?mt=8)：实用且精致的任务管理类应用，以量化的方式激励你完成目标
+* :white_check_mark: [Lazy K](https://itunes.apple.com/cn/app/lazy-k/id1348224910?mt=8): 不想聊天的敷衍“输入法” - [更多介绍](https://sspai.com/post/43386)
+* :white_check_mark: [小目标](https://itunes.apple.com/cn/app/%E5%B0%8F%E7%9B%AE%E6%A0%87-%E9%87%8F%E5%8C%96%E4%BD%A0%E7%9A%84%E8%BF%9B%E6%AD%A5/id1215312957?mt=8): 实用且精致的任务管理类应用，以量化的方式激励你完成目标
 
 #### Gao Deng - [Github](https://github.com/gaodeng)
 * :white_check_mark: [AtPill](https://itunes.apple.com/cn/app/id590504521?mt=12): (Mac) 豆瓣电台客户端
-* :white_check_mark: [HaloRadio](https://www.icyarrow.com/haloradio/)：(Windows) 豆瓣电台客户端
-* :white_check_mark: [Biu](https://github.com/gaodeng/Biu-for-ReadHub)：(Android/iOS) Readhub 移动客户端
+* :white_check_mark: [HaloRadio](https://www.icyarrow.com/haloradio/): (Windows) 豆瓣电台客户端
+* :white_check_mark: [Biu](https://github.com/gaodeng/Biu-for-ReadHub): (Android/iOS) Readhub 移动客户端
 
 #### ymark - [GitHub](https://github.com/ymma)
-* :white_check_mark: [易词云](http://yciyun.com)：根据各种图片模板生成词云图片
-* :white_check_mark: [易LOGO](http://yeelogo.com/)：简单的在线生成 Logo 网站
-* :clock8: [二维码梦工厂](http://qrdream.ymark.cc/)：专注于个性、动态、扁平、表情二维码生成
+* :white_check_mark: [易词云](http://yciyun.com): 根据各种图片模板生成词云图片
+* :white_check_mark: [易LOGO](http://yeelogo.com/): 简单的在线生成 Logo 网站
+* :clock8: [二维码梦工厂](http://qrdream.ymark.cc/): 专注于个性、动态、扁平、表情二维码生成
 
 #### GhostSKB - [GitHub](https://github.com/dingmingxin/GhostSKB)
-* :white_check_mark: [GhostSKB](https://itunes.apple.com/cn/app/ghostskb/id1134384859?mt=12)：(Mac) 可根据应用设置默认输入法，应用切换时，输入法也跟随切换
+* :white_check_mark: [GhostSKB](https://itunes.apple.com/cn/app/ghostskb/id1134384859?mt=12): (Mac) 可根据应用设置默认输入法，应用切换时，输入法也跟随切换
 
 #### simpleapples - [GitHub](https://github.com/simpleapples)
-* :white_check_mark: [Fanskey](https://github.com/simpleapples/fansky)：Third-party FanFou iOS App
-* :white_check_mark: [摇摇选餐](https://github.com/simpleapples/ShakeChoose)：随机选餐工具
-* :white_check_mark: [短网址二维码生成器](https://github.com/simpleapples/url2qrcode)：Chrome 短网址二维码生成器
+* :white_check_mark: [Fanskey](https://github.com/simpleapples/fansky): Third-party FanFou iOS App
+* :white_check_mark: [摇摇选餐](https://github.com/simpleapples/ShakeChoose): 随机选餐工具
+* :white_check_mark: [短网址二维码生成器](https://github.com/simpleapples/url2qrcode): Chrome 短网址二维码生成器
 * :white_check_mark: [App Store 全部作品](https://itunes.apple.com/cn/developer/zhiya-zang/id549139622)
 
 ### 2018, March 17
@@ -463,56 +463,56 @@ If you are unsure whether your project meets this list's criteria, please contac
 * :white_check_mark: [RapInChina](https://rapinchina.com/): 中文说唱数据库 - [更多介绍](https://wanqu.io/t/rapinchina/7371)
 
 #### KyXu - [GitHub](https://github.com/OpenMarshall), [微博](http://weibo.com/kaiyuanxu)
-* :white_check_mark: [Nihon](https://itunes.apple.com/app/id1315486029)：在 iOS 上呈现日本传统颜色 - [更多介绍](https://wanqu.io/t/nihon-ios/7678)
-* :white_check_mark: [闪念](https://itunes.apple.com/cn/app/id1342519507)：在 iPhone 上尽力复刻了锤子的 Idea Pills - [更多介绍](https://wanqu.io/t/iphone-idea-pill/8038)
-* :white_check_mark: [记分牌](https://itunes.apple.com/cn/app/id1080572635)：(iOS) NBA 比分跟踪利器 - [更多介绍](https://wanqu.io/t/ios-mac-nba/8051)
-* :white_check_mark: [Basketball Moment](https://itunes.apple.com/cn/app/id1185284010)：(Mac) NBA 比分跟踪利器 - [更多介绍](https://wanqu.io/t/ios-mac-nba/8051)
-* :white_check_mark: [时间规划局](https://itunes.apple.com/cn/app/id1204689405)：提醒珍惜时间的 iOS Today Widget
-* :white_check_mark: [飞花令](https://itunes.apple.com/cn/app/id1340671116)：用三十万古诗词数据打造的极简飞花令主题 App
+* :white_check_mark: [Nihon](https://itunes.apple.com/app/id1315486029): 在 iOS 上呈现日本传统颜色 - [更多介绍](https://wanqu.io/t/nihon-ios/7678)
+* :white_check_mark: [闪念](https://itunes.apple.com/cn/app/id1342519507): 在 iPhone 上尽力复刻了锤子的 Idea Pills - [更多介绍](https://wanqu.io/t/iphone-idea-pill/8038)
+* :white_check_mark: [记分牌](https://itunes.apple.com/cn/app/id1080572635): (iOS) NBA 比分跟踪利器 - [更多介绍](https://wanqu.io/t/ios-mac-nba/8051)
+* :white_check_mark: [Basketball Moment](https://itunes.apple.com/cn/app/id1185284010): (Mac) NBA 比分跟踪利器 - [更多介绍](https://wanqu.io/t/ios-mac-nba/8051)
+* :white_check_mark: [时间规划局](https://itunes.apple.com/cn/app/id1204689405): 提醒珍惜时间的 iOS Today Widget
+* :white_check_mark: [飞花令](https://itunes.apple.com/cn/app/id1340671116): 用三十万古诗词数据打造的极简飞花令主题 App
 * :white_check_mark: [App Store 全部作品](https://itunes.apple.com/cn/developer/id988271193)
 
 #### wyan453351466
-* :white_check_mark: [言说](https://www.yanshuo.me/)：高质量的内容分享社区（reddit中文版）- [更多介绍](https://wanqu.io/t/reddit/7267)
+* :white_check_mark: [言说](https://www.yanshuo.me/): 高质量的内容分享社区（reddit中文版）- [更多介绍](https://wanqu.io/t/reddit/7267)
 
 #### 61
-* :white_check_mark: [PriceTag](https://itunes.apple.com/cn/app/price-tag/id1166819590?mt=8)：应用资讯即刻知晓
+* :white_check_mark: [PriceTag](https://itunes.apple.com/cn/app/price-tag/id1166819590?mt=8): 应用资讯即刻知晓
 
 #### oldj
-* :white_check_mark: [妙笔](https://www.momothink.com/wonderpen)：Mac 平台写作软件 - [更多介绍](https://blog.momothink.com/2016/11/21/hello-wonderpen/)
-* :white_check_mark: [SwitchHosts!](https://oldj.github.io/SwitchHosts/)：便捷的 Hosts 管理工具 - [更多介绍](https://github.com/oldj/SwitchHosts)
+* :white_check_mark: [妙笔](https://www.momothink.com/wonderpen): Mac 平台写作软件 - [更多介绍](https://blog.momothink.com/2016/11/21/hello-wonderpen/)
+* :white_check_mark: [SwitchHosts!](https://oldj.github.io/SwitchHosts/): 便捷的 Hosts 管理工具 - [更多介绍](https://github.com/oldj/SwitchHosts)
 
 #### Kenshin
-* :white_check_mark: [简悦](http://ksria.com/simpread/)：让你瞬间进入沉浸式阅读的 Chrome 扩展 - [更多介绍](https://wanqu.io/t/200-chrome/7181)    
-* :white_check_mark: [Emoji](http://ksria.com/emoji/)：一个简单、可靠、纯粹、中文语义化的 Emoji 扩展
+* :white_check_mark: [简悦](http://ksria.com/simpread/): 让你瞬间进入沉浸式阅读的 Chrome 扩展 - [更多介绍](https://wanqu.io/t/200-chrome/7181)    
+* :white_check_mark: [Emoji](http://ksria.com/emoji/): 一个简单、可靠、纯粹、中文语义化的 Emoji 扩展
 
 #### jadeydi
-* :white_check_mark: [TopTalkedBooks](https://toptalkedbooks.com/)：收集 Hacker News, Stack Overflow, Reddit 书，展示推荐最多的书 - [更多介绍](https://wanqu.io/t/hacker-news-stack-overflow-reddit-2017-09-04/) 
+* :white_check_mark: [TopTalkedBooks](https://toptalkedbooks.com/): 收集 Hacker News, Stack Overflow, Reddit 书，展示推荐最多的书 - [更多介绍](https://wanqu.io/t/hacker-news-stack-overflow-reddit-2017-09-04/) 
 
 #### soasme
-* :white_check_mark: [Techshack Weekly](https://wanqu.io/t/techshack-weekly/7809)：精细耕耘后端开发的每一个知识点 - [更多介绍](https://wanqu.io/t/techshack-weekly/7809)
+* :white_check_mark: [Techshack Weekly](https://wanqu.io/t/techshack-weekly/7809): 精细耕耘后端开发的每一个知识点 - [更多介绍](https://wanqu.io/t/techshack-weekly/7809)
 
 #### wwayne
-* :white_check_mark: [Cominsoon](https://cominsoon.io/)：快速搭建『即将上线』页面 - [更多介绍](https://wanqu.io/t/cominsoon/7676/4)
+* :white_check_mark: [Cominsoon](https://cominsoon.io/): 快速搭建『即将上线』页面 - [更多介绍](https://wanqu.io/t/cominsoon/7676/4)
 
 #### 寂小桦
-* :white_check_mark: [小专栏](https://xiaozhuanlan.com/)：专业人士的写作社区 - [更多介绍](https://www.v2ex.com/t/392109)
+* :white_check_mark: [小专栏](https://xiaozhuanlan.com/): 专业人士的写作社区 - [更多介绍](https://www.v2ex.com/t/392109)
 
 #### 像素君
-* :white_check_mark: [Creater-lion 导航](http://chuangzaoshi.com)：创意工作者导航
+* :white_check_mark: [Creater-lion 导航](http://chuangzaoshi.com): 创意工作者导航
 
 #### wichna
-* :white_check_mark: [Paybase](https://paybase.cn)：一个专注于支付领域的垂直论坛 - [更多介绍](https://wanqu.io/t/paybase/7891)
-* :white_check_mark: [Anyshortcut](https://anyshortcut.com/)：一款 Chrome/Firefox 效率插件，自定义快捷键快速打开常用网站 - [更多介绍](https://wanqu.io/t/anyshorcut-chrome/7648/9)
+* :white_check_mark: [Paybase](https://paybase.cn): 一个专注于支付领域的垂直论坛 - [更多介绍](https://wanqu.io/t/paybase/7891)
+* :white_check_mark: [Anyshortcut](https://anyshortcut.com/): 一款 Chrome/Firefox 效率插件，自定义快捷键快速打开常用网站 - [更多介绍](https://wanqu.io/t/anyshorcut-chrome/7648/9)
 
 #### 猫叔 - [GitHub](https://github.com/imeoer), [Blog](http://www.chole.io/)
-* :clock8: [纸小墨](https://www.v2ex.com/t/393185#reply710)：全平台笔记软件
+* :clock8: [纸小墨](https://www.v2ex.com/t/393185#reply710): 全平台笔记软件
 
 #### 1c7 - [GitHub](https://github.com/1c7), [Weibo](https://weibo.com/2004104451/profile?topnav=1&wvr=6)
-* :white_check_mark: [寓住](https://yuzhu.me)：找长租公寓/评价长租公寓
-* :white_check_mark: [Sideidea](http://sideidea.com)：独立开发者分享做项目盈利的故事，目前内容均翻译自 Indie Hacker，暂无原创内容。
-* :white_check_mark: [CC 速成班](coolapk.com/apk/com.crashcourse.china.c17)：聚合所有中文字幕 Crash Course 视频 - [更多介绍](https://wanqu.io/t/app-cc-crash-course/7606)
-* :x: youtube-sumup.com：总结 Youtube 视频内容
-* :x: 月可(onereco.com)：写短总结推荐好文
+* :white_check_mark: [寓住](https://yuzhu.me): 找长租公寓/评价长租公寓
+* :white_check_mark: [Sideidea](http://sideidea.com): 独立开发者分享做项目盈利的故事，目前内容均翻译自 Indie Hacker，暂无原创内容。
+* :white_check_mark: [CC 速成班](coolapk.com/apk/com.crashcourse.china.c17): 聚合所有中文字幕 Crash Course 视频 - [更多介绍](https://wanqu.io/t/app-cc-crash-course/7606)
+* :x: youtube-sumup.com: 总结 Youtube 视频内容
+* :x: 月可(onereco.com): 写短总结推荐好文
 
 ---
 


### PR DESCRIPTION
In the English version, it is more appropriate to use a half-width colon `:` instead of a full-width colon `：`.

Hope this help in standardizing future translation format :)
