### PR TITLE
fix: 更新链接 - Morestrive

### DIFF
--- a/README-Programmer-Edition.md
+++ b/README-Programmer-Edition.md
@@ -218,7 +218,7 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 ### 2023年8月4日添加
 ---
 #### Morestrive - [Github](https://github.com/more-strive)
-* :white_check_mark: [vue-fabric-design](https://more-strive.github.io/design/)：基于 Canvas 的开源版"创客贴"，在线生成名片、海报、宣传单，支持 文字、图片、形状、线条、二维码 、条形码等 - [更多介绍](https://github.com/more-strive/vue-fabric-design)
+* :white_check_mark: [vue-fabric-design](https://yft.design/)：基于 Canvas 的开源版"创客贴"，在线生成名片、海报、宣传单，支持 文字、图片、形状、线条、二维码 、条形码等 - [更多介绍](https://github.com/dromara/yft-design)
 
 ### 2023年8月2日添加
 ---


### PR DESCRIPTION
链接更新说明：
原有的链接在访问后会跳转到修改后的仓库链接，而原有的项目介绍页404，更新的项目介绍页链接来自跳转后的仓库。