### PR TITLE
添加 MusiCard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@
 
 ## 3. 项目列表
 
+### 2026 年 6 月 5 号添加
+
+#### shadycheer - [Github](https://github.com/shadycheer)
+* :white_check_mark: [MusiCard](https://musi-card-two.vercel.app)：音乐分享卡生成工具，Spotify / Apple Music 链接转高清图卡，自动拉歌词可选词嵌入，专为国内聊天场景设计
+
 ### 2026 年 6 月 4 号添加
 
 #### Cheng 


### PR DESCRIPTION
## 项目信息

- **名称**：MusiCard
- **链接**：https://musi-card-two.vercel.app
- **作者**：shadycheer（https://github.com/shadycheer）
- **仓库**：https://github.com/shadycheer/MusiCard （开源 MIT）

## 简介

音乐分享卡生成工具，Spotify / Apple Music 链接转高清图卡，自动拉歌词可选词嵌入，为分享而生。

## 做这个的初衷

国内分享 Spotify 链接到微信只是一串 URL 没人会点；Apple Music 自带分享卡在国内拿不到封面图。MusiCard 把"分享一首歌"压缩成一张图：聊天里一眼就能看到歌名、艺人、封面、想突出的几句歌词、扫码直达的二维码，不需要别人点击一个不知道是什么的链接。

每个平台有完全不同的视觉语言（Spotify 黑底绿点 / Apple Music 封面提色渐变 + 空间歌词 fade），不是简单的"换主题色"。