### PR TITLE
Remove unused `datetime` import to fix lint warning

### DIFF
--- a/.github/scripts/process_item.py
+++ b/.github/scripts/process_item.py
@@ -1,7 +1,7 @@
 # 自动扫描 GitHub Issues 中被标记为 🚀 的项目提交，通过 AI 格式化后批量添加到 README 并创建 Pull Request。
 import os
 import re
-import datetime
+
 from github import Github 
 from openai import OpenAI
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
This PR addresses a lint warning in `.github/scripts/process_item.py` where the `datetime` module was imported but unused due to a redefinition. The warning indicated that `datetime` from line 3 (`import datetime`) was redefined by the more specific import on line 6 (`from datetime import datetime, timedelta, timezone`). Removing the unused import improves code clarity and eliminates the lint issue without affecting functionality.

**Changes:**
- Removed the `import datetime` statement on line 3, as the necessary components (`datetime`, `timedelta`, `timezone`) are already imported via `from datetime import ...` on line 6.

**Verification:**
- Confirmed that all uses of `datetime`, `timedelta`, and `timezone` in the code remain correctly referenced.
- No functional changes; the script's behavior is unchanged.