### PR TITLE
修正：将 Witchspire / Cursemark Builds 移到游戏版面

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,6 @@
 #### junwei000 - [Github](https://github.com/junwei000)
 * :white_check_mark: [aniv](https://aniv.ai)：一站式 AI 创作工具站，浏览器打开即用：AI 文生图、AI 文生视频、视频画质增强、字幕合成
 
-#### Wang Hongbo
-* :white_check_mark: [Witchspire](https://witchspire.org)：暗黑幻想 roguelite 游戏，动态法术系统+契约系统，Steam 6月10日 EA 上线 - [更多介绍](https://witchspire.org/about)
-* :white_check_mark: [Cursemark Builds](https://cursemark.org)：Cursemark 游戏 Build 数据库，50+ 法术组合+社群评分+符文指南，完全免费无需注册
-
 ### 2026 年 6 月 24 号添加
 
 #### 刀刀 - [Github](https://github.com/sfss5362)

--- a/pages/README-Game.md
+++ b/pages/README-Game.md
@@ -2,6 +2,12 @@
 
 本版面放的都是游戏，起始于2025年1月4号
 
+### 2026 年 6 月 25 号添加
+
+#### Wang Hongbo
+* :white_check_mark: [Witchspire](https://witchspire.org)：暗黑幻想 roguelite 游戏，动态法术系统+契约系统，Steam 6月10日 EA 上线 - [更多介绍](https://witchspire.org/about)
+* :white_check_mark: [Cursemark Builds](https://cursemark.org)：Cursemark 游戏 Build 数据库，50+ 法术组合+社群评分+符文指南，完全免费无需注册
+
 ### 2026 年 6 月 18 号添加
 
 #### hwlvipone - [Github](https://github.com/hwlvipone)


### PR DESCRIPTION
Wang Hongbo 提交的两个游戏类产品之前被错误归类到主版面，移到游戏版面