### PR TITLE
新增：AudienceCue

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ### 2026 年 7 月 1 号添加
 
 #### woshiliyana - [Github](https://github.com/woshiliyana)
-* :white_check_mark: [AudienceCue](https://audiencecue.com/en/tools/youtube-comment-downloader)：YouTube 公开视频评论下载和受众分析工具，粘贴视频或 Shorts 链接即可导出 CSV，并把评论整理成带证据的受众报告
+* :white_check_mark: [AudienceCue](https://audiencecue.com/zh/tools/youtube-comment-downloader)：YouTube 公开视频评论下载和受众分析工具，粘贴视频或 Shorts 链接即可导出 CSV，并把评论整理成带证据的受众报告
 
 ### 2026 年 6 月 30 号添加
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 
 ## 3. 项目列表
 
+### 2026 年 7 月 1 号添加
+
+#### woshiliyana - [Github](https://github.com/woshiliyana)
+* :white_check_mark: [AudienceCue](https://audiencecue.com/en/tools/youtube-comment-downloader)：YouTube 公开视频评论下载和受众分析工具，粘贴视频或 Shorts 链接即可导出 CSV，并把评论整理成带证据的受众报告
+
 ### 2026 年 6 月 30 号添加
 
 #### yeshimin(温州) - [Github](https://github.com/yeshimin)


### PR DESCRIPTION
添加 AudienceCue：YouTube 公开视频评论下载和受众分析工具。

提交内容：
- 在 2026 年 7 月 1 号添加分组下加入 AudienceCue
- 使用可直接打开的中文免费工具页作为链接

链接已检查：`https://audiencecue.com/zh/tools/youtube-comment-downloader` 返回 200。