### PR TITLE
添加 upload（跨 AI 的长期记忆层）到主版面

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 
 ## 3. 项目列表
 
+### 2026 年 7 月 12 号添加
+
+#### Banlon - [Github](https://github.com/Banlon)
+* :white_check_mark: [upload](https://upload.one)：跨 AI 的长期记忆层，让 ChatGPT、Claude、Codex、Hermes、OpenClaw、WorkBuddy 等共用同一份记忆，换工具换设备都接着上次继续，注册即用免装插件
+
 ### 2026 年 7 月 11 号添加
 
 #### cabbagehao - [Github](https://github.com/vivifyvideo/vivify)


### PR DESCRIPTION
按 CONTRIBUTING 格式，把 upload 添加到主版面项目列表。

- 产品：upload（https://upload.one） · 状态：已上线 ✅
- 一句话：跨 AI 的长期记忆层，让 ChatGPT、Claude、Codex 等共用同一份记忆，换工具换设备都接着上次继续，注册即用、免装插件
- 面向普通用户，打开即用（注册后在网页里管理记忆，或把 ChatGPT / Claude 连上，无需写代码）

感谢维护这个列表 🙏