### PR TITLE
docs: 添加 markstream-vue

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,11 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 7 月 13 号添加
+
+#### Simon He(上海) - [Github](https://github.com/Simon-He95)
+* :white_check_mark: [markstream-vue](https://github.com/Simon-He95/markstream-vue)：面向 AI 聊天的 Vue 3 / Nuxt 流式 Markdown 渲染器，可稳定渲染持续到达且未完成的 Markdown，支持 Mermaid、KaTeX、Shiki 和 Monaco
+
 ### 2026 年 7 月 10 号添加
 
 #### AI Router - [Github](https://github.com/airouter-dev)


### PR DESCRIPTION
## 项目介绍

markstream-vue 是面向 AI 聊天场景的 Vue 3 / Nuxt 流式 Markdown 渲染器，可稳定渲染持续到达且未完成的 Markdown，并支持 Mermaid、KaTeX、Shiki 和 Monaco。

## 修改内容

- 按照 CONTRIBUTING.md 的格式添加作者、GitHub 链接、项目链接和一句话介绍
- 根据项目需要通过 npm 安装并集成代码的特点，将条目加入程序员版面

项目地址：https://github.com/Simon-He95/markstream-vue