### PR TITLE
新增项目：SaaSCity（海外）

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@
 #### MuRong - [Github](https://github.com/murongg)
 * :white_check_mark: [Markra](https://editor.markra.app/)：本地优先的开源所见即所得 Markdown 编辑器，支持 Web、macOS、Windows 和 Linux，AI 修改可预览后应用 - [更多介绍](https://github.com/markrahq/markra/blob/main/README.zh-CN.md)
 
+#### ghosty(海外) - [Github](https://github.com/n1-ghosty)
+* :white_check_mark: [SaaSCity](https://saascity.io)：免费提交 SaaS 产品，每个产品会变成等距城市地图上的一栋建筑，24 小时内人工审核上线，付费版附带 dofollow 外链
+
 ### 2026 年 7 月 12 号添加
 
 #### Banlon - [Github](https://github.com/Banlon)


### PR DESCRIPTION
在「2026 年 7 月 13 号添加」中新增 **SaaSCity**。

```
#### ghosty(海外) - [Github](https://github.com/n1-ghosty)
* :white_check_mark: [SaaSCity](https://saascity.io)：免费提交 SaaS 产品，每个产品会变成等距城市地图上的一栋建筑，24 小时内人工审核上线，付费版附带 dofollow 外链
```

对照入选标准：
- [x] 是网站，打开即用
- [x] 不是开发者工具，也不是论坛型网站（是产品目录，和列表里已有的 AIInLink 同类）
- [x] 已上线 :white_check_mark:
- [x] 介绍语写了具体能做什么，不是空泛的品类名

Ahrefs DR 46。免费收录即有独立产品页；付费版额外提供 dofollow 外链和地图展示位。