### PR TITLE
添加 Aural 开源 AI 面试平台

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 7 月 14 号添加
 
+#### 1146345502 - [Github](https://github.com/1146345502)
+* :white_check_mark: [Aural](https://aural-ai.com)：开源 AI 面试平台，支持语音、聊天和视频面试，提供自适应追问、结构化评分、面试练习与自托管 - [查看仓库](https://github.com/1146345502/aural-oss)
+
 #### Tristan Tang - [Github](https://github.com/tristan666666)
 * :white_check_mark: [Agent Island](https://agent-island.dev/)：Claude Code 与 Codex 的开源状态伴侣，在 macOS 和 Windows 上显示实时会话状态，并在需要你接手时提醒；本地监控，无需账号 - [查看仓库](https://github.com/tristan666666/agent-island)
 


### PR DESCRIPTION
## 项目介绍

添加 [Aural](https://aural-ai.com)：开源 AI 面试平台，支持语音、聊天和视频面试，提供自适应追问、结构化评分、面试练习与自托管。

开源仓库：https://github.com/1146345502/aural-oss

## 检查

- 按 `CONTRIBUTING.md` 的格式添加到当天项目列表
- 在线产品与开源仓库链接均已验证可访问
- `python3 -m unittest discover -s tests -v` 通过（4/4）