### PR TITLE
添加 SeatView 真实座位视角图集

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 
 ## 3. 项目列表
 
+### 2026 年 7 月 15 号添加
+
+#### Sallyn - [Github](https://github.com/Sallyn0225)
+* :white_check_mark: [SeatView](https://seat.genchi.top)：日本及部分海外演唱会场馆的真实座位视角图集，在坐席图上点击标注即可查看该位置的实拍视野，浏览和上传均无需注册 - [查看仓库](https://github.com/Sallyn0225/seatview)
+
 ### 2026 年 7 月 14 号添加
 
 #### Tristan Tang - [Github](https://github.com/tristan666666)


### PR DESCRIPTION
## 项目介绍

添加已上线项目 **SeatView**：聚合日本及部分海外演唱会场馆的真实座位视角照片，用户可以在坐席图上点击标注查看对应位置的实拍视野，浏览和上传均无需注册。

- 在线地址：https://seat.genchi.top
- 项目仓库：https://github.com/Sallyn0225/seatview
- 项目状态：已上线

## 本次改动

- 按照 `CONTRIBUTING.md` 的格式将 SeatView 添加到项目列表
- 省略城市名，保留制作者 GitHub 与项目仓库链接