### PR TITLE
新增：WillowTab

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 ### 2026 年 7 月 15 号添加
 
 #### Un1quer - [Github](https://github.com/Un1quer23)
-* :white_check_mark: [WillowTab](https://chromewebstore.google.com/detail/willowtab/gfigaeaddejhmnlkeppgccklahgepapm)：极简浏览器新标签页扩展，支持多搜索引擎切换、本地壁纸、深浅色主题和外观自定义，无需账号且不收集个人数据 - [查看仓库](https://github.com/Un1quer23/WillowTab)
+* :white_check_mark: [WillowTab](https://chromewebstore.google.com/detail/willowtab/gfigaeaddejhmnlkeppgccklahgepapm)：极简浏览器新标签页扩展，支持多搜索引擎切换、本地壁纸、深浅色主题和外观自定义，无需账号且不收集个人数据 - [Edge 商店安装](https://microsoftedge.microsoft.com/addons/detail/willowtab/ljkgjcbecpanckomdgebinggfhpkmmph) - [查看仓库](https://github.com/Un1quer23/WillowTab)
 
 #### 喜欢电脑的猫咪 - [Github](https://github.com/xhdndmm), [博客](https://blog.xhdndmm.net)
 * :white_check_mark: [123pan](https://github.com/123panNextGen/123pan/releases/latest)：开源第三方 123 云盘桌面客户端，支持 Windows 和 Linux，提供文件管理、多账号、多线程传输、限速和代理设置 - [查看仓库](https://github.com/123panNextGen/123pan)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 7 月 15 号添加
 
+#### Un1quer - [Github](https://github.com/Un1quer23)
+* :white_check_mark: [WillowTab](https://chromewebstore.google.com/detail/willowtab/gfigaeaddejhmnlkeppgccklahgepapm)：极简浏览器新标签页扩展，支持多搜索引擎切换、本地壁纸、深浅色主题和外观自定义，无需账号且不收集个人数据 - [查看仓库](https://github.com/Un1quer23/WillowTab)
+
 #### 喜欢电脑的猫咪 - [Github](https://github.com/xhdndmm), [博客](https://blog.xhdndmm.net)
 * :white_check_mark: [123pan](https://github.com/123panNextGen/123pan/releases/latest)：开源第三方 123 云盘桌面客户端，支持 Windows 和 Linux，提供文件管理、多账号、多线程传输、限速和代理设置 - [查看仓库](https://github.com/123panNextGen/123pan)
 


### PR DESCRIPTION
## 修改内容

- 在 2026 年 7 月 15 日新增项目中加入 WillowTab
- 使用 Chrome Web Store 作为产品主链接，并提供 Edge Add-ons 安装入口
- 补充 GitHub 仓库链接及一句话产品介绍

## 项目说明

WillowTab 是一款极简浏览器新标签页扩展，支持多搜索引擎切换、本地壁纸、深浅色主题和外观自定义，无需账号且不收集个人数据，可从 Chrome Web Store 和 Edge Add-ons 安装。

## 检查

- `python -m unittest discover -s tests -v`（4 项通过）
- `git diff --check`
- Chrome Web Store、Edge Add-ons 和 GitHub 仓库链接可访问