### PR TITLE
在 7 月 15 日区域添加 jaychouchannel 项目条目

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@
 #### Sallyn - [Github](https://github.com/Sallyn0225)
 * :white_check_mark: [SeatView](https://seat.genchi.top)：日本及部分海外演唱会场馆的真实座位视角图集，在坐席图上点击标注即可查看该位置的实拍视野，浏览和上传均无需注册 - [查看仓库](https://github.com/Sallyn0225/seatview)
 
+#### jaychouchannel - [Github](https://github.com/jaychouchannel)
+* :white_check_mark: [旅游综合管理平台](https://github.com/jaychouchannel/Tourism_Management_System)：基于 Spring Boot + MyBatis-Plus + Vue.js + MySQL 的全功能旅游管理平台，一站式管理景点、酒店、餐厅、线路、导游、门票及社区互动 - [查看仓库](https://github.com/jaychouchannel/Tourism_Management_System)
+
 ### 2026 年 7 月 14 号添加
 
 #### EthanYoQ - [GitHub](https://github.com/EthanYoQ)


### PR DESCRIPTION
## 摘要
在 README 的 2026 年 7 月 15 号添加区域新增个人项目条目，格式与已收录条目一致。

## 项目信息
- 项目名：旅游综合管理平台
- 仓库：https://github.com/jaychouchannel/Tourism_Management_System
- 技术栈：Spring Boot + MyBatis-Plus + Vue.js + MySQL
- 简介：全功能旅游管理平台，一站式管理景点、酒店、餐厅、线路、导游、门票及社区互动
- 状态：已上线 ✅

## 测试清单
- [x] 格式与同日期其他条目一致（用户名链接到 GitHub 主页，项目链接到仓库，附"查看仓库"链接）
- [x] 使用 `:white_check_mark:` 状态图标
- [x] 添加位置正确：7 月 15 日区域末尾，7 月 14 日区域之前

🤖 Generated with [Claude Code](https://claude.com/claude-code)