### PR TITLE
Add Synthesizer Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 
 ## 3. 项目列表
 
+### 2026 年 7 月 16 号添加
+
+#### Misaki-Akeno(杭州) - [Github](https://github.com/Misaki-Akeno)
+* :white_check_mark: [Synthesizer Flow](https://synthesizer-flow.misakif.uk/)：浏览器端模块化合成器，通过可视化节点和连线搭建音频工作流，支持实时声音合成、MIDI 音序及 AI Agent 辅助修改工程
+
 ### 2026 年 7 月 15 号添加
 
 #### zeplios(北京) - [Github](https://github.com/zeplios)


### PR DESCRIPTION
## 变更内容

- 在主版面新增独立开发项目 Synthesizer Flow
- 添加开发者 GitHub、所在地杭州及产品正式域名

## 项目简介

Synthesizer Flow 是浏览器端模块化合成器，通过可视化节点和连线搭建音频工作流，支持实时声音合成、MIDI 音序及 AI Agent 辅助修改工程。

## 检查

- 已按 CONTRIBUTING.md 的条目格式添加
- 正式域名可正常访问并返回 HTTP 200
- `git diff --check` 通过
