### PR TITLE
新增：PlotCraft（AI 驱动的科研论文矢量图生成器）

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
 ## 3. 项目列表
 ### 2026 年 7 月 21 号添加
 
+#### jaychouchannel - [Github](https://github.com/jaychouchannel)
+* :white_check_mark: [PlotCraft](https://github.com/jaychouchannel/PlotCraft)：科研人专用，用自然语言描述图表，AI 自动生成 Nature/Cell 级科研论文矢量图（SVG），支持 8 种图表模板，本地沙箱渲染，让论文配图不再麻烦。
+
 #### aqua5230 - [Github](https://github.com/aqua5230)
 * :white_check_mark: [usage](https://github.com/aqua5230/usage)：把 Claude Code / Codex 的剩余额度和烧钱速度实时显示在菜单栏，全程不占用官方额度
 


### PR DESCRIPTION
## 新增

在 2026 年 7 月 21 号添加了 jaychouchannel 的 [PlotCraft](https://github.com/jaychouchannel/PlotCraft)：
- AI 驱动的科研论文矢量图生成器，用自然语言描述图表即可生成 Nature/Cell 级 SVG
- 支持 8 种图表模板，本地沙箱渲染，API 密钥加密存储

## 变更

- `README.md`：在 2026-07-21 段落最上方新增条目

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>