### PR TITLE
更新 Lumi Finder 已上架 App 数量至 29 款

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 * :white_check_mark: [Zivoe](https://zivoe.elolin.com)：面向工业设计的桌面工具，用一张参考图把模糊想法变成产品概念主图和三视图，启发灵感、也方便和工厂沟通
 
 #### alice51849 - [Github](https://github.com/alice51849)
-* :white_check_mark: [Lumi & Friends iOS App Finder](https://alice51849.github.io/ios-app-guide/zh-Hans/tools/private-pay-once-iphone-app-finder.html)：按用途、隐私和付费方式查找 28 款已上架 iPhone/iPad App，覆盖学习、效率、照片、旅行与健康，逐款直达 App Store；支持 Apple 官方 50 个本地化区域
+* :white_check_mark: [Lumi & Friends iOS App Finder](https://alice51849.github.io/ios-app-guide/zh-Hans/tools/private-pay-once-iphone-app-finder.html)：按用途、隐私和付费方式查找 29 款已上架 iPhone/iPad App，覆盖学习、效率、照片、旅行与健康，逐款直达 App Store；支持 Apple 官方 50 个本地化区域
 
 #### 小明 - [Github](https://github.com/xiaomingio)
 * :white_check_mark: [Vibe Coding Atlas](https://vibecoding.aicake.io)：中国独立开发者项目列表网页版，每日刷新 Markdown 清单生成可搜索筛选的静态目录，并补充公开 GitHub Stars - [GitHub 仓库](https://github.com/xiaomingio/vibe-coding-atlas)


### PR DESCRIPTION
## 更新内容

Lumi & Friends iOS App Finder 的已验证上架 App 已由 28 款增加至 29 款，本 PR 仅同步现有条目的公开数量，不新增重复条目。

- 公开 Finder：29 款已上架 iPhone/iPad App
- Apple 官方 50 个本地化区域
- 每款结果保留 App Store 直达链接
- 公开目录数据：`app_count=29`、`locale_count=50`、`record_count=1450`

Finder：https://alice51849.github.io/ios-app-guide/zh-Hans/tools/private-pay-once-iphone-app-finder.html
公开目录：https://alice51849.github.io/ios-app-guide/data/lumi-studio-publisher-search-intent-catalog.json