### PR TITLE
修正 Orkas 官网来源参数

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@
 * :white_check_mark: [ExcaliRec](https://excalirec.com/)：浏览器白板录屏工具，面向 Excalidraw 风格讲解视频，支持自动聚焦缩放和本地录制，无需安装或注册
 
 #### Orkas - [Github](https://github.com/Orkas-AI/Orkas)
-* :white_check_mark: [Orkas](https://orkas.ai?source=github)：AI 团队桌面 App，开源、本地优先，通过对话下达目标，由指挥官协调专业 Agent 完成调研、文档、数据分析、编程和视频等复杂任务；支持官方模型，也可接入自己的模型
+* :white_check_mark: [Orkas](https://orkas.ai?source=github_chinese_independent_developer)：AI 团队桌面 App，开源、本地优先，通过对话下达目标，由指挥官协调专业 Agent 完成调研、文档、数据分析、编程和视频等复杂任务；支持官方模型，也可接入自己的模型
 
 #### Indie Fox - [Github](https://github.com/open-fox), [Blog](https://mkdollar.com)
 * :white_check_mark: [MkImage](https://mkimage.ai)：AI 生图工具站，内置 1000+ 优质提示词，支持 GPT Image 和 NanoBanana 等模型


### PR DESCRIPTION
将 Orkas 官网链接中通用的 `source=github` 改为列表专属的 `source=github_chinese_independent_developer`，便于准确区分从本项目跳转到官网的访问来源。

仅修改 URL 查询参数，不改动项目介绍。