### PR TITLE
自荐:cocodot LLM 降智检测(免费在线工具)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 7 月 24 号添加
 
+#### cocodot2026 - [GitHub](https://github.com/cocodot2026)
+* :white_check_mark: [cocodot LLM 降智检测](https://probe.cocodot.co)：免费的 LLM API「降智/偷换模型」在线检测：填入任意 OpenAI 兼容端点的 base_url 和临时 API Key，跑 6 项探针（模型声明、动态题、能力完整性等）生成分项报告；Key 仅用于当次检测、不落库不留存，检测方法[开源](https://github.com/cocodot2026/cocodot-llmprobe)
+
 #### KKWANG4444 - [GitHub](https://github.com/KKWANG4444)
 * :white_check_mark: [AI快站模型质量检测](https://docs.aifast.club/model-check/)：面向 OpenAI Compatible 接口的网页检测工具，输入公开 HTTPS 地址和临时 API Key，可检查模型声明、Token、动态题、SSE 与工具调用并生成分项报告；密钥仅用于当次检测，不写入数据库、缓存或日志
 


### PR DESCRIPTION
自荐一个免费工具,按 7 月 24 号日期段格式添加:

**[cocodot LLM 降智检测](https://probe.cocodot.co)** —— LLM API「降智/偷换模型」在线检测:填入任意 OpenAI 兼容端点的 base_url 和临时 API Key,跑 6 项探针(模型声明、动态题、能力完整性等)生成分项报告。API Key 仅用于当次检测、不落库不留存;检测方法完全[开源](https://github.com/cocodot2026/cocodot-llmprobe)。

利益相关:我们是该工具的开发者(cocodot 团队),工具本身免费、无需注册即可用。感谢维护这份榜单!