### PR TITLE
新增 CrewBee、PilotDeck、Waggle 到程序员版面

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,13 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 7 月 29 号添加
+
+#### Perrin Yong(上海) - [Github](https://github.com/PerrinYong)
+* :white_check_mark: [CrewBee](https://github.com/CrewBeeLab/CrewBee)：AI Agent 团队框架，面向 OpenCode 将角色、工作流、审查流程与完成标准封装为可复用团队资产，内置 Coding Team；一条 `npx` 命令安装 - [更多介绍](https://www.crewbee.art)
+* :white_check_mark: [PilotDeck](https://github.com/PilotDeckAgentLabs/PilotDeck)：ProjectOps × AgentOps 控制台，集中管理 AI Agent 协作、项目进展、审计轨迹与 token/成本；基于 Flask、Vue 3 与 SQLite 自托管部署
+* :white_check_mark: [Waggle](https://github.com/CrewBeeLab/Waggle)：AI Agent 治理运行时与控制平面，以项目为执行边界，提供权限控制、工具强制、确认流程、运行事件与审计证据；支持 CLI、HTTP 与 TypeScript SDK，需自托管部署
+
 ### 2026 年 7 月 28 号添加
 
 #### zhangxuyuan20251443-coder - [Github](https://github.com/zhangxuyuan20251443-coder)


### PR DESCRIPTION
## 变更

- 在 2026 年 7 月 29 日区块新增 Perrin Yong 的作者信息
- 将 CrewBee、PilotDeck、Waggle 三个已上线项目加入程序员版面
- 按 CONTRIBUTING 模板补充产品类型、核心能力和安装/部署特征

## 归类依据

- CrewBee 通过 `npx` 安装并运行于 OpenCode
- PilotDeck 需要安装 Python/Node.js 依赖并自托管
- Waggle 需要 Node.js、pnpm 或 Docker 环境并自托管

因此三个项目均归入程序员版面，不进入面向普通用户打开即用的主版面。

## 验证

- 已按完整 URL 检查三个项目在所有 README 中均未重复
- 已核对项目页面、README、安装/部署方式和链接可访问性
- `python -m pytest -q`：4 passed
