### PR TITLE
新增：Agent4API

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 7 月 30 号添加
 
+#### apoet - [GitHub](https://github.com/apoet)
+* :white_check_mark: [Agent4API](https://agent4api.ecrfs.com/admin)：导入 Swagger 2.0 或 OpenAPI 3.x 文档，一键理解接口业务能力并生成 Tools、Skills 和 Agents；通过 MCP、OpenAI/Anthropic 兼容 API、内置 Chat 与嵌入式 Chat 对外提供服务，支持 Docker Compose 自托管部署 - [源码](https://github.com/apoet/Agent4API)
+
 #### iAmCorey - [Github](https://github.com/iAmCorey)
 * :white_check_mark: [Birth](https://github.com/iAmCorey/birth)：管理 Mac 启动项，显示每个自启项的开发者签名身份、标红伪装系统项，支持一键启停与安全删除 — 免费开源 macOS App
 

--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -18,9 +18,6 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 
 ### 2026 年 7 月 30 号添加
 
-#### apoet - [GitHub](https://github.com/apoet)
-* :white_check_mark: [Agent4API](https://github.com/apoet/Agent4API)：导入 Swagger 2.0 或 OpenAPI 3.x 文档，一键理解接口业务能力并生成 Tools、Skills 和 Agents；通过 MCP、OpenAI/Anthropic 兼容 API、内置 Chat 与嵌入式 Chat 对外提供服务，支持 Docker Compose 自托管部署 - [在线演示](https://agent4api.ecrfs.com/admin)
-
 #### Gang Qu - [GitHub](https://github.com/stomeonst)
 * :white_check_mark: [Public Trend Signal MVP](https://github.com/stomeonst/public-trend-signal-mvp)：把授权导出的 JSONL 趋势记录标准化、去重、确定性评分并拆分人工复核队列，导出飞书或 Notion 可导入的 CSV 和带哈希的运行回执；使用虚构样例，不抓取社交平台
 

--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -18,6 +18,9 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 
 ### 2026 年 7 月 30 号添加
 
+#### apoet - [GitHub](https://github.com/apoet)
+* :white_check_mark: [Agent4API](https://github.com/apoet/Agent4API)：导入 Swagger 2.0 或 OpenAPI 3.x 文档，一键理解接口业务能力并生成 Tools、Skills 和 Agents；通过 MCP、OpenAI/Anthropic 兼容 API、内置 Chat 与嵌入式 Chat 对外提供服务，支持 Docker Compose 自托管部署 - [在线演示](https://agent4api.ecrfs.com/admin)
+
 #### Gang Qu - [GitHub](https://github.com/stomeonst)
 * :white_check_mark: [Public Trend Signal MVP](https://github.com/stomeonst/public-trend-signal-mvp)：把授权导出的 JSONL 趋势记录标准化、去重、确定性评分并拆分人工复核队列，导出飞书或 Notion 可导入的 CSV 和带哈希的运行回执；使用虚构样例，不抓取社交平台
 


### PR DESCRIPTION
## 修改内容

在主版面 2026 年 7 月 30 日分组新增 Agent4API，包含作者主页、在线演示、核心能力简介和源码链接。

## 项目简介

Agent4API 可将 Swagger 2.0 / OpenAPI 3.x 接口自动编排为 Tools、Skills 和 Agents，并通过 MCP、OpenAI/Anthropic 兼容 API及 Chat 形态提供服务。

## 验证

- 已按 CONTRIBUTING.md 的格式编写
- 最终差异仅修改主版面 README.md
- git diff --check 通过