### PR TITLE
新增：BaZi Calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 8 月 1 号添加
 
+#### Yana Li - [Github](https://github.com/woshiliyana)
+* :white_check_mark: [BaZi Calculator](https://bazicalculators.com/)：免费在线八字排盘工具，输入出生日期、时间和城市即可查看四柱、日主、五行、十神与大运；无需注册，出生时间未知时提供三柱命盘，不猜测时柱
+
 #### Chris - [Github](https://github.com/stomeonst)
 * :white_check_mark: [CJK SaaS Localization QA Pack](https://stomeonst.github.io/cjk-saas-localization-qa-pack-preview/)：中日 SaaS 本地化质检模板包，提供简体中文与日语的术语表、界面检查表、缺陷记录和发布验收清单，可在线查看样例并购买可编辑文件 - [查看仓库](https://github.com/stomeonst/cjk-saas-localization-qa-pack-preview)
 


### PR DESCRIPTION
## 变更

- 在 2026 年 8 月 1 日项目列表中新增 BaZi Calculator。
- 使用现有贡献格式，标注制作者、正式产品地址和核心功能。

## 原因与影响

BaZi Calculator 是中国独立开发者制作、打开即用的网站，符合主版面的网站或 App 收录标准。合并后，读者可以从项目列表发现这款免费、无需注册的在线八字排盘工具。

## 验证

- 正式地址 `https://bazicalculators.com/` 返回 HTTP 200。
- README、Issue 和 PR 中未发现同一产品的重复记录。
- `python3 -m unittest tests/test_process_item.py`：4 项测试通过。
- `git diff --check`：通过。
