### PR TITLE
添加不空钓鱼天气

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 
 ## 3. 项目列表
 
+### 2026 年 8 月 7 号添加
+
+#### 不空团队 - [Github](https://github.com/Hanshihao111)
+* :white_check_mark: [不空：钓鱼天气与鱼情记录](https://bhtq.cn)：面向野钓用户的钓鱼天气与分鱼种鱼情工具，网页免登录查询十种目标鱼的当前评分、未来24小时趋势和较好时段；iPhone App另提供未来7日鱼情、私有钓点和鱼获记录 - [App Store](https://apps.apple.com/cn/app/id6791599314)
+
 ### 2026 年 8 月 6 号添加
 
 #### AKAama(南京) - [Github](https://github.com/AKAama), [个人主页](https://ismyh.cn/)


### PR DESCRIPTION
## 修改内容

- 在2026年8月7日条目中增加“不空：钓鱼天气与鱼情记录”。
- 提供官网、GitHub作者主页和App Store公开链接。
- 描述网页免登录查询十种目标鱼、未来24小时趋势，以及iPhone App的未来7日鱼情、私有钓点和鱼获记录能力。

## 提交原因

不空是已经上线的网站和iPhone App，符合主版面“打开即用的网站或App”收录标准。

## 核验

- `git diff --check`通过。
- 官网、GitHub主页和App Store链接均返回HTTP 200。
- 提交内容只有README中的一个产品条目，没有修改其他项目。
