### PR TITLE
添加 AI 比价：全网 AI 信息聚合比价站

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 8 月 7 号添加
 
+#### the-beating-light-of-the-nail - [Github](https://github.com/the-beating-light-of-the-nail)
+* :white_check_mark: [AI 比价](https://www.china-ai-arbitrage.xyz)：全网 AI 信息聚合比价站——国产官方套餐（GLM / Kimi / 通义 / 豆包等）的真实 Token 额度与限速、各家 API 单价、免费 Token 活动、低价 API 中转与海外账号行情一张表横向比，按「每元可用量」选出最划算方案
+
 #### 不空团队 - [Github](https://github.com/Hanshihao111)
 * :white_check_mark: [不空：钓鱼天气与鱼情记录](https://bhtq.cn)：面向野钓用户的钓鱼天气与分鱼种鱼情工具，网页免登录查询十种目标鱼的当前评分、未来 24 小时趋势和较好时段；iPhone App 另提供未来 7 日鱼情、私有钓点和鱼获记录 - [App Store](https://apps.apple.com/cn/app/id6791599314)
 


### PR DESCRIPTION
AI 比价（china-ai-arbitrage.xyz）是一个全球化的 AI编程服务比价与内容站。核心解决一个痛点：同类大模型在不同平台、不同渠道（官方订阅 vs API
  中转）的价格差异巨大，且信息分散、价格常变、额度规则复杂，开发者很难一眼看出最优解。

  站点提供 8 大板块：套餐对比（21+ 家平台逐项比价）、API 中转报价板（聚合多家 reseller 实时报价）、账号报价板（ChatGPT /  Claude / Gemini / Grok / Codex 等共享与独享账号行情）、额度实测（标注真实可用量而非宣传额度）、免费 Token
  汇总、模型详情页（价格 + 上下文 + 能力标签）、深度博客与FAQ。
  技术特点：Nuxt 3 全栈 SSR + Vue 3，原生 i18n 支持 24 种语言，SEO 优先（自动 hreflang / canonical / sitemap /
  JSON-LD），部署于 Vercel 边缘网络。内容静态数据驱动，更新及时、加载极快。