### PR TITLE
添加 Nexus Shell（原生 macOS SSH 客户端）

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,11 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 8 月 10 号添加
+
+#### Sameral - [Github](https://github.com/viewer12)
+* :white_check_mark: [Nexus Shell](https://nexusshell.app/?utm_source=github&utm_medium=referral&utm_campaign=chinese_independent_developer)：原生 macOS SSH 客户端，在一个应用中管理终端、双栏 SFTP、Docker 与服务器监控；还可通过 MCP 让 Claude Code、Codex 在可见终端中执行已授权操作，密码和私钥不会交给 Agent
+
 ### 2026 年 8 月 9 号添加
 
 #### mebtte - [Github](https://github.com/mebtte)


### PR DESCRIPTION
自荐，我是 Nexus Shell 的开发者。

这次只在程序员版新增一条：Nexus Shell 是面向开发者、运维和 VPS 用户的原生 macOS SSH 客户端，因此没有放到面向普通用户的主版面。

介绍语按 CONTRIBUTING 的格式说明了终端、双栏 SFTP、Docker、服务器监控，以及 Agent Bridge 的授权边界。产品为商业闭源应用，基础 SSH 功能可免费使用；没有将其描述为开源项目。

验证：`python3 -m unittest discover -s tests -v`（4 项通过）。