### PR TITLE
移除不空钓鱼天气条目

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,6 @@
 #### the-beating-light-of-the-nail - [Github](https://github.com/the-beating-light-of-the-nail)
 * :white_check_mark: [AI 比价](https://www.china-ai-arbitrage.xyz)：全网 AI 信息聚合比价站——国产官方套餐（GLM / Kimi / 通义 / 豆包等）的真实 Token 额度与限速、各家 API 单价、免费 Token 活动、低价 API 中转与海外账号行情一张表横向比，按「每元可用量」选出最划算方案
 
-#### 不空团队 - [Github](https://github.com/Hanshihao111)
-* :white_check_mark: [不空：钓鱼天气与鱼情记录](https://bhtq.cn)：面向野钓用户的钓鱼天气与分鱼种鱼情工具，网页免登录查询十种目标鱼的当前评分、未来 24 小时趋势和较好时段；iPhone App 另提供未来 7 日鱼情、私有钓点和鱼获记录 - [App Store](https://apps.apple.com/cn/app/id6791599314)
-
 ### 2026 年 8 月 6 号添加
 
 #### AKAama(南京) - [Github](https://github.com/AKAama), [个人主页](https://ismyh.cn/)


### PR DESCRIPTION
不空当前不再参与独立开发者目录推广。此变更仅删除此前由不空官方提交的产品条目，不影响其他项目。