### PR TITLE
添加 Riffpad

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,11 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 8 月 11 号添加
+
+#### Liu Zhening - [Github](https://github.com/hypervapor)
+* :white_check_mark: [Riffpad](https://riffpad.ai)：把 Claude Code、Codex 等 AI 编程 agent 加密同步到手机，躺床上也能看进度、一键批准操作、远程补一句新指令；代码和 API key 只留在你电脑上，端到端加密 - [GitHub](https://github.com/riffpad/riffpad)
+
 ### 2026 年 8 月 10 号添加
 
 #### Sameral - [Github](https://github.com/viewer12)


### PR DESCRIPTION
添加 [Riffpad](https://riffpad.ai) 到**程序员版**。

Riffpad 是开源（Apache-2.0）的命令行工具：本地 daemon 把 Claude Code、Codex 等 AI coding agent **加密同步到手机**，在手机上看进度、批准操作、远程补指令；端到端加密，代码和 API key 只留在用户电脑上。

属于「使用需要命令行」的类型，所以放到程序员版面。
