### PR TITLE
修正 Dopastep 条目：免费额度与免注册说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 * :white_check_mark: [Kindly-Web](https://github.com/ClauBloom/Kindly-Web)：开源 Chrome 浏览器插件，自动扫描评论区（目前已适配 Bilibili），调用大语言模型将带有攻击性、阴阳怪气或负面情绪的评论实时重写为和谐、友善且理性的表达 - [更多介绍](https://www.bilibili.com/video/BV17ugj6qEx2)
 
 #### 王冲 - [Github](https://github.com/androidwangchong)
-* :white_check_mark: [Dopastep](https://dopastep.com/zh/?utm_source=cnindie&utm_medium=github)：把你一直不想动的那件事拆成小到不用下决心就能开始的第一步，然后进实时专注房和别人按同一节奏做事（body doubling）；不用开摄像头、没有聊天、不用预约配对，专注段与休息段全房同步——Deep Work 房每天一场固定时间（北京 21:00），其余房间的 25/5 循环全天在跑，进去就能接上；不注册也能直接拆任务、直接进房坐下；支持 12 种语言（中文含简繁），任务拆解跟随任务本身的语言而非界面语言；免费每月 3 次拆解 + 公共专注房，Pro 10 美元/月
+* :white_check_mark: [Dopastep](https://dopastep.com/zh/?utm_source=cnindie&utm_medium=github)：把你一直不想动的那件事拆成小到不用下决心就能开始的第一步，然后进实时专注房和别人按同一节奏做事（body doubling）；不用开摄像头、没有聊天、不用预约配对，专注段与休息段全房同步——Deep Work 房每天一场固定时间（北京 21:00），其余房间的 25/5 循环全天在跑，进去就能接上；不注册也能直接拆任务、直接进房坐下；支持 12 种语言（中文含简繁），任务拆解跟随任务本身的语言而非界面语言；免费每月 3 次拆解 + 公共专注房，Pro 10 美元/月，年付 80 美元
 
 ### 2026 年 8 月 12 号添加
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 * :white_check_mark: [Kindly-Web](https://github.com/ClauBloom/Kindly-Web)：开源 Chrome 浏览器插件，自动扫描评论区（目前已适配 Bilibili），调用大语言模型将带有攻击性、阴阳怪气或负面情绪的评论实时重写为和谐、友善且理性的表达 - [更多介绍](https://www.bilibili.com/video/BV17ugj6qEx2)
 
 #### 王冲 - [Github](https://github.com/androidwangchong)
-* :white_check_mark: [Dopastep](https://dopastep.com/zh/?utm_source=cnindie&utm_medium=github)：把你一直不想动的那件事拆成小到不用下决心就能开始的第一步，然后进实时专注房和别人按同一节奏做事（body doubling）；不用开摄像头、没有聊天、不用预约配对，专注段与休息段全房同步，不注册也能先看房里有几个人；支持 12 种语言（中文含简繁），任务拆解跟随任务本身的语言而非界面语言；免费 10 次拆解 + 公共专注房，Pro 10 美元/月
+* :white_check_mark: [Dopastep](https://dopastep.com/zh/?utm_source=cnindie&utm_medium=github)：把你一直不想动的那件事拆成小到不用下决心就能开始的第一步，然后进实时专注房和别人按同一节奏做事（body doubling）；不用开摄像头、没有聊天、不用预约配对，专注段与休息段全房同步——Deep Work 房每天一场固定时间（北京 21:00），其余房间的 25/5 循环全天在跑，进去就能接上；不注册也能直接拆任务、直接进房坐下；支持 12 种语言（中文含简繁），任务拆解跟随任务本身的语言而非界面语言；免费每月 3 次拆解 + 公共专注房，Pro 10 美元/月
 
 ### 2026 年 8 月 12 号添加
 


### PR DESCRIPTION
只改自己那一行（第 60 行），不涉及其他条目。

原描述有两处与实际不符，本次一并更正：

1. **免费额度**：原写「免费 10 次拆解」。那是我提交上一个 PR 当天早些时候的规则，在合并之前我就改成了**每月 3 次、按月重置**。所以那行从上线起就是错的，抱歉。

2. **「不注册也能先看房里有几个人」**：这句已经不适用了。房间列表现在显示的是场次时间和专注/休息进度，不再显示人数。

顺带把描述里更有用的一点补上：**不注册就能直接拆任务，也能直接进房间坐下**（填个名字即可，不需要账号）。原来的描述把这件事说得比实际更受限。

其余内容（无摄像头 / 无聊天 / 不用预约配对、12 种语言、拆解跟随任务本身的语言、Pro 10 美元/月）保持不变，均与实际一致。