### PR TITLE
Add DSH Meme Hub listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 * :white_check_mark: [SeatingChartGenerator](https://www.seatingchartgenerator.app)：免费在线座位表生成器，支持拖拽安排婚礼、派对、教室和活动宾客，完成后可导出 PNG 或 PDF
 #### linuxscreen - [Github](https://github.com/linuxscreen)
 * :white_check_mark: [Duo Translator](https://duotranslator.com/)：AI翻译和写作助手（浏览器插件），支持网页双语翻译、划词翻译、写作增强、YouTube双语字幕等功能 - [项目与下载](https://github.com/linuxscreen/duo-translator)
+#### the-beating-light-of-the-nail - [Github](https://github.com/the-beating-light-of-the-nail)
+* :white_check_mark: [DSH Meme Hub](https://dsh-meme-hub.cdqyfdbymn.me/)：DeepSeek Harness 社区插件导航站，收录 87 个插件、13 个分类，每日更新 star 排行榜，整活插件单独放进 Meme Zone，中英双语，开放投稿 - [GitHub 项目](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub)
 
 ### 2026 年 8 月 14 号添加
 


### PR DESCRIPTION
添加一个独立开发的导航站项目 DSH Meme Hub。

DeepSeek Harness 是 DeepSeek 开源的 agent 运行时，社区里涌现了大量插件，从正经的文件管理器、Git 面板到桌面鲸鱼娘宠物、整活广告，但散落在各个仓库里没人整理。这个站把能找到的都翻了一遍，收录 87 个插件、13 个分类，每个插件有独立详情页、截图和一句话点评，按 star 排了每日更新的趋势榜，整活插件单独放进 Meme Zone。中英双语，也开放投稿。

项目纯前端静态站，Nuxt 3 构建，部署在 Vercel，代码开源在 https://github.com/the-beating-light-of-the-nail/dsh-meme-hub-site 。
