### PR TITLE
Add DSH Studio to programmer edition

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,11 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 8 月 16 号添加
+
+#### Moresyl - [Github](https://github.com/Moresyl)
+* :white_check_mark: [DSH Studio](https://github.com/Moresyl/dsh-studio)：本地优先的跨平台 DeepSeek Harness 桌面管理器，用图形界面完成安装、启动停止、健康检查、日志查看与进程清理，提供 Windows、macOS 和 Linux 安装包
+
 ### 2026 年 8 月 14 号添加
 
 #### 钟智强 - [Github](https://github.com/ctkqiang), [博客](https://ctkqiang.xin)


### PR DESCRIPTION
## 说明

将 DSH Studio 收录到程序员版，而不是面向普通用户的主版面。

DSH Studio 是 MIT 开源的跨平台 DeepSeek Harness 桌面管理器，提供安装、启动停止、健康检查、日志查看和进程清理，并发布 Windows、macOS 与 Linux 安装包。

## 检查

- 已按 CONTRIBUTING.md 的制作者与项目格式填写
- 已放入程序员版最新日期分组
- 已搜索 README、Issues 和 PR，未发现重复
- python -m unittest discover -s tests -v：4 项测试通过

维护者说明：我是 DSH Studio 的维护者。