### PR TITLE
fix(Dopastep): 价格改成实际收费的人民币，并去掉会过期的场次钟点

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 8 月 21 号添加
 
+#### 王冲 - [Github](https://github.com/androidwangchong)
+* :white_check_mark: [Dopastep](https://dopastep.com/zh/?utm_source=cnindie&utm_medium=github)：把你一直不想动的那件事拆成小到不用下决心就能开始的第一步，然后进实时专注房和别人按同一节奏做事（body doubling）；不用开摄像头、没有聊天、不用预约配对，专注段与休息段全房同步——Deep Work 房每天有固定场次（页面按你所在时区显示下一场几点），其余房间的 25/5 循环全天在跑，进去就能接上；不注册也能直接拆任务、直接进房坐下；支持 12 种语言（中文含简繁），任务拆解跟随任务本身的语言而非界面语言；免费每月 3 次拆解 + 公共专注房，Pro ¥25/月、¥198/年（中国大陆价，其他地区按当地货币结算）
+
 #### Sword - [Github](https://github.com/330132662/douyin)
 * :white_check_mark: [DouYin](https://gitee.com/jeffcat/douyin)：抖音 AI 获客助手，VLM 视觉大模型自动分析视频画面，按关键词条件自动点赞收藏，支持散步模式和评论区意向客户筛选，Android 无障碍服务免 Root 运行
 
@@ -101,9 +104,6 @@
 
 #### ClauBloom(北京) - [Github](https://github.com/ClauBloom)
 * :white_check_mark: [Kindly-Web](https://github.com/ClauBloom/Kindly-Web)：开源 Chrome 浏览器插件，自动扫描评论区（目前已适配 Bilibili），调用大语言模型将带有攻击性、阴阳怪气或负面情绪的评论实时重写为和谐、友善且理性的表达 - [更多介绍](https://www.bilibili.com/video/BV17ugj6qEx2)
-
-#### 王冲 - [Github](https://github.com/androidwangchong)
-* :white_check_mark: [Dopastep](https://dopastep.com/zh/?utm_source=cnindie&utm_medium=github)：把你一直不想动的那件事拆成小到不用下决心就能开始的第一步，然后进实时专注房和别人按同一节奏做事（body doubling）；不用开摄像头、没有聊天、不用预约配对，专注段与休息段全房同步——Deep Work 房每天一场固定时间（北京 21:00），其余房间的 25/5 循环全天在跑，进去就能接上；不注册也能直接拆任务、直接进房坐下；支持 12 种语言（中文含简繁），任务拆解跟随任务本身的语言而非界面语言；免费每月 3 次拆解 + 公共专注房，Pro 10 美元/月，年付 80 美元
 
 ### 2026 年 8 月 12 号添加
 


### PR DESCRIPTION
更新我自己的 Dopastep 条目，两处改动：

**1. 价格写错了市场。** 条目对中文读者写的是「Pro 10 美元/月，年付 80 美元」，但 Paddle 对中国大陆地址实际按 **¥25/月、¥198/年** 结算。读者看到的价格比实际贵近三倍，还会误以为要用国际信用卡——两个都是劝退点，而且都不成立。改成人民币实价，并注明其他地区按当地货币结算。

**2. 场次钟点会过期。** 原文写「Deep Work 房每天一场固定时间（北京 21:00）」，实际已经不止一场、时间也在调整。页面本来就按读者所在时区显示下一场几点，所以改成不绑定具体钟点的表述，避免这句话再次失效。

因为是实质更新而不是补几个字，我把条目**移到了今天的日期段，没有新增重复条目**——列表里仍然只有一条 Dopastep。如果您更希望原地修改、不移动位置，我可以改成那样。