### PR TITLE
添加 YiBoard：在线棋类对战平台 (yiboardgame.com)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
 
 ### 2026 年 8 月 21 号添加
 
+#### 863683348 - [Github](https://github.com/863683348)
+* :white_check_mark: [YiBoard](https://yiboardgame.com/?utm_source=cnindie&utm_medium=github)：浏览器里直接下的棋类平台——免费对真实 AI 引擎或好友下五子棋，无需账号、无需下载，从「九级」一路升到「九段」的 18 级天梯；中国象棋和围棋也已列入路线图
+
 #### 王冲 - [Github](https://github.com/androidwangchong)
 * :white_check_mark: [Dopastep](https://dopastep.com/zh/?utm_source=cnindie&utm_medium=github)：把你一直不想动的那件事拆成小到不用下决心就能开始的第一步，然后进实时专注房和别人按同一节奏做事（body doubling）；不用开摄像头、没有聊天、不用预约配对，专注段与休息段全房同步——Deep Work 房每天有固定场次（页面按你所在时区显示下一场几点），其余房间的 25/5 循环全天在跑，进去就能接上；不注册也能直接拆任务、直接进房坐下；支持 12 种语言（中文含简繁），任务拆解跟随任务本身的语言而非界面语言；免费每月 3 次拆解 + 公共专注房，Pro ¥25/月、¥198/年（中国大陆价，其他地区按当地货币结算）
 


### PR DESCRIPTION
## 新增项目

[YiBoard](https://yiboardgame.com) — 在线棋类对战（工具型 · 免费网页游戏 · 棋类爱好者/休闲玩家向）

**一句话介绍**：浏览器里直接下的棋类平台——免费对真实 AI 引擎或好友下五子棋，无需账号、无需下载，从「九级」一路升到「九段」的 18 级天梯；中国象棋和围棋也已列入路线图。

**English**: Play Gomoku free against a real engine or a friend — no account, no download, with an eighteen-rung ladder from Ninth Grade to Ninth Dan. Xiangqi and Go are coming next.