### PR TITLE
docs: add OrcaRouter to programmer edition list

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,11 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 8 月 22 号添加
+
+#### OrcaRouter
+* :white_check_mark: [OrcaRouter](https://www.orcarouter.ai)：OpenAI 兼容 AI 网关，一个 Key 接入 Claude/GPT/Gemini/DeepSeek 等模型，自适应路由 + 自动故障转移 + 推理零加价，同一端点内建 AI Agent 零信任安全（默认拒绝），无需改应用代码
+
 ### 2026 年 8 月 21 号添加
 
 #### ckfanzhe - [Github](https://github.com/ckfanzhe)


### PR DESCRIPTION
## Add OrcaRouter to the Programmer Edition list

This PR adds [OrcaRouter](https://www.orcarouter.ai) to the **程序员版** (Programmer Edition) list, in the same section that already features AI gateway products such as [TeamoRouter](https://teamorouter.com) and [CoderPlan](https://coderplan.ai).

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding orcarouter as a first-class provider means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

This repo is a curated index of independent-developer projects, and the Programmer Edition is exactly where command-line/API users browse for tools like this. The entry follows the existing format and sits alongside the other AI gateway entries.

**Verification**
- Added the entry under a new `### 2026 年 8 月 22 号添加` section at the top of `pages/README-Programmer-Edition.md`.
- Live-tested the OpenAI-compatible endpoint `https://api.orcarouter.ai/v1/chat/completions` (model `orcarouter/free`) — HTTP 200.
- Ran the repo's unit tests (`python3 -m unittest tests/test_process_item.py`) — all 4 pass.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
