### PR TITLE
新增 AIXiamo：ChatGPT Plus / Pro 国内订阅代付服务

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@
 
 ## 3. 项目列表
 
+### 2026 年 8 月 22 号添加
+
+#### momochoog - [Github](https://github.com/momochoog)
+* :white_check_mark: [AIXiamo](https://www.aixiamo.com/?utm_source=cnindie&utm_medium=github)：ChatGPT Plus / Pro 国内充值与订阅代付服务，面向没有海外银行卡的用户，支持支付宝、USDT、订单查询与 7×24 小时客服入口；独立第三方，非 OpenAI 官方 - [公开教程与服务说明](https://github.com/momochoog/gpt-daichong)
+
 ### 2026 年 8 月 21 号添加
 
 #### 863683348 - [Github](https://github.com/863683348)


### PR DESCRIPTION
## 变更内容

- 将 AIXiamo 加入 2026-08-22 的独立开发者项目列表。
- 链接公开官网和 GitHub 教程。
- 使用公开可核验的支付方式、订单查询和客服入口信息。

## 关联披露

我是 AIXiamo 运营方。AIXiamo 是独立第三方服务，与 OpenAI 无隶属或官方合作关系。本条目未写成第三方评测或官方推荐。

## 核验来源

- https://www.aixiamo.com/
- https://github.com/momochoog/gpt-daichong
