### PR TITLE
修正 Lumi Finder 条目里已过期的 App 数量

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,7 +449,7 @@
 * :white_check_mark: [Zivoe](https://zivoe.elolin.com)：面向工业设计的桌面工具，用一张参考图把模糊想法变成产品概念主图和三视图，启发灵感、也方便和工厂沟通
 
 #### alice51849 - [Github](https://github.com/alice51849)
-* :white_check_mark: [Lumi & Friends iOS App Finder](https://alice51849.github.io/ios-app-guide/zh-Hans/tools/private-pay-once-iphone-app-finder.html)：按用途、隐私和付费方式查找 29 款已上架 iPhone/iPad App，覆盖学习、效率、照片、旅行与健康，逐款直达 App Store；支持 Apple 官方 50 个本地化区域
+* :white_check_mark: [Lumi & Friends iOS App Finder](https://alice51849.github.io/ios-app-guide/zh-Hans/tools/private-pay-once-iphone-app-finder.html)：按用途、隐私和付费方式查找已上架的 iPhone/iPad App，覆盖学习、效率、照片、旅行与健康，逐款直达 App Store；支持 Apple 官方 50 个本地化区域
 
 #### 小明 - [Github](https://github.com/xiaomingio)
 * :white_check_mark: [Vibe Coding Atlas](https://vibecoding.aicake.io)：中国独立开发者项目列表网页版，每日刷新 Markdown 清单生成可搜索筛选的静态目录，并补充公开 GitHub Stars - [GitHub 仓库](https://github.com/xiaomingio/vibe-coding-atlas)


### PR DESCRIPTION
我是这个条目的作者，来更正自己填的一个数字。

条目里写的「29 款已上架」是 7 月的数字，现在实际上架数量已经不是这个了（美区 44、国区 37，刚用 Apple iTunes Lookup API 查过）。

这次直接把数字去掉，改成「已上架的 iPhone/iPad App」。上架数量每次发新 App 都会变，写死一个数字就意味着过一阵子又会错一次，不如不写。

只改了一行，没有新增任何 App、没有动其他人的条目。