### PR TITLE
新增：DSH Meme Hub（程序员版）

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,11 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 8 月 28 号添加
+
+#### the-beating-light-of-the-nail - [Github](https://github.com/the-beating-light-of-the-nail)
+* :white_check_mark: [DSH Meme Hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub-site)：DeepSeek Harness 社区插件导航站的 Nuxt 3 全栈源码，收录 87 个插件、13 个分类、每日 star 排行榜与 Meme Zone 整活分区，中英双语，SSG 静态生成，开放投稿 — [线上站点](https://dsh-meme-hub.cdqyfdbymn.me/)
+
 ### 2026 年 8 月 27 号添加
 
 #### KiddPhenix - [Github](https://github.com/KiddPhenix)


### PR DESCRIPTION
按照 README 格式，在程序员版 2026 年 8 月 28 号添加 分节新增了我的开源项目 **DSH Meme Hub**（Nuxt 3 全栈源码）。

- DeepSeek Harness 社区插件导航站源码：87 个插件、13 个分类、每日 star 排行榜
- Meme Zone 整活分区，中英双语
- Nuxt 3 SSG 静态生成，开放投稿
- 线上站点：https://dsh-meme-hub.cdqyfdbymn.me/

之前主版面已收录网站版（PR #1277 已合并），这次补上程序员版的开源源码条目。谢谢！