### PR TITLE
添加 HelloGen - AI 图片和视频生成工作台

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
 #### Viki Wu - [Github](https://github.com/wxixuan118-ship-it)
 * :white_check_mark: [FishCare AI](https://www.fishcareai.com/)：观赏鱼饲养指南与免费工具站，买鱼前先查混养兼容性（4000+ 鱼种组合对照页）、鱼缸最小尺寸、水质参数和投喂量，覆盖斗鱼、孔雀鱼、七彩神仙等常见品种，免费无需注册
 
+#### chenchiwei - [Github](https://github.com/chenchiwei)
+* :white_check_mark: [HelloGen](https://hellogen.ai/)：AI 图片和视频生成工作台，图片免费不限量、无水印、可商用，视频按次计费；助手根据需求自动选模型（Seedream、Nano Banana、GPT Image 2、Veo、Kling、Seedance），生成前先报价，失败不扣费
+
 ### 2026 年 8 月 28 号添加
 
 #### Lisa W (Berlin)


### PR DESCRIPTION
在「2026 年 8 月 30 号添加」下补一条自己的项目。

```
#### chenchiwei - [Github](https://github.com/chenchiwei)
* :white_check_mark: [HelloGen](https://hellogen.ai/)：AI 图片和视频生成工作台，图片免费不限量、无水印、可商用，视频按次计费；助手根据需求自动选模型（Seedream、Nano Banana、GPT Image 2、Veo、Kling、Seedance），生成前先报价，失败不扣费
```

介绍语按 CONTRIBUTING 的「先定性，再加分」写：先说清楚是什么（AI 图片和视频生成工作台），再说不一样的地方——图片免费不限量且无水印可商用，视频生成前先报价、失败不扣费。

符合入选标准：是网站，打开即用，不是开发者工具或论坛。状态 :white_check_mark:（已上线）。