### PR TITLE
新增 XiuStore：AI 订阅和数字服务商城

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@
 
 #### Cairne - [Github](https://github.com/cairne)
 * :white_check_mark: [Image3D AI](https://www.aiimageto3d.com/)：AI 图片转 3D 模型平台，集成 Tripo、Meshy、Hunyuan、Pixal3D 等多个 3D 生成模型，并提供 AI 贴图、Retopology、UV 展开和模型组件分离工具，从图片生成到 3D 后处理可在一个平台完成
+
+#### Dashu
+* :white_check_mark: [XiuStore](https://store.xiu.ai/en/)：AI 订阅和数字服务商城，商品页公开价格、交付方式、有效期、质保和售后，付款后可在订单中找到对应交付入口
   
 ### 2026 年 9 月 1 号添加
 


### PR DESCRIPTION
## 变更内容

- 在 2026 年 9 月 2 日的主版面新增 Dashu 的 XiuStore。
- XiuStore 是打开即可浏览的在线商城，不需要命令行或本地部署，因此放在主版面。
- 描述只使用买家可见的价格、交付方式、有效期、质保、售后和订单交付入口事实。

## 核验

- 提交前 README、程序员版面、游戏版面、Issue 和 PR 中均无 XiuStore 或 `store.xiu.ai`。
- https://store.xiu.ai/en/ 当前返回 HTTP 200。
- `python3 -m unittest discover -s tests -v`：4 个测试通过。
- `git diff --check` 和本机 pre-push gate 通过。
- 仅修改 README.md，新增 3 行。

## 关联披露

这是项目方自荐。XiuStore 由 Dashu 参与公开构建，XiuAI 及其产品由 XiuLab Inc 运营。AI assistance 用于查重、事实核验和格式检查；未写收入、销量、用户数、评价或动态价格。