### PR TITLE
Add Blood of Dawnwalker Tools (2026-09-07)

### DIFF
--- a/pages/README-Game.md
+++ b/pages/README-Game.md
@@ -10,6 +10,9 @@
 #### firegomove(广东) - [Github](https://github.com/firegomove)
 * :white_check_mark: [PixelArtGame](https://pixelartgame.online/)：一款结合了像素艺术与轻松玩法的网页游戏。无需下载安装，打开即可游玩。游戏以复古像素画风为核心，配合轻快的背景音乐，营造出沉浸式的游戏体验。无论是怀旧玩家还是休闲爱好者，都能快速找到属于自己的乐趣
 
+#### [提交者名] - [Github](https://github.com/YOUR_GITHUB)
+* :white_check_mark: [Blood of Dawnwalker Tools](https://bloodofdawnwalker.win)：The Blood of Dawnwalker 粉丝工具站，含 Vampire/Human 构建计算器、7 结局追踪器和 47 奖杯清单，浏览器直接使用，无需注册账号
+
 ### 2026 年 8 月 28 号添加
 
 #### ethanethan(上海) - [Github](https://github.com/lianyixin)


### PR DESCRIPTION
## Add Blood of Dawnwalker Tools to 游戏版面

**Link:** https://bloodofdawnwalker.win  
**Description:** The Blood of Dawnwalker 粉丝工具站，含 Vampire/Human 构建计算器、7 结局追踪器和 47 奖杯清单，浏览器直接使用，无需注册账号

**Section suggestion:** 游戏版面 / 2026 年 9 月

Reason: Fan-made tools site for The Blood of Dawnwalker (Bandai Namco 2026 action-RPG). Provides build calculator, endings tracker, and trophy checklist — three tools that help players make decisions in under 30 seconds. No account required, runs entirely in browser.