### PR TITLE
添加 TeamoRouter（程序员版面）

### DIFF
--- a/pages/README-Programmer-Edition.md
+++ b/pages/README-Programmer-Edition.md
@@ -16,6 +16,11 @@ Issue 和 PR 里偶尔有人提交一些不错的东西，但打开一看，不�
 程序员版开始于 2019 年 4 月 11 号, 主版面开始于 2018 年 3 月
 -->
 
+### 2026 年 9 月 8 号添加
+
+#### TeamoRouter
+* :white_check_mark: [TeamoRouter](https://teamorouter.cn)：多模型 AI API 中转网关，GPT-6 Astra / Claude / Gemini 用一个 Key 调用，Codex 和 Claude Code 改 base_url 即用，支持支付宝/微信充值、按量计费 - [Astra + Codex 配置教程](https://teamorouter.cn/blogs/gpt-6-astra-codex-cursor-setup)
+
 ### 2026 年 9 月 6 号添加
 
 #### Tony Chen - [Github](https://github.com/zhiqingchen)


### PR DESCRIPTION
在 `pages/README-Programmer-Edition.md` 新增条目，按 CONTRIBUTING 模板（制作者 + :white_check_mark: 行 + 一句话介绍）。

- 介绍语参照同版面 Sub2API / XiuRouter / LuckyAPI 的写法：先定性（多模型 AI API 中转网关），再列功能点（GPT-6 Astra / Claude / Gemini 一个 Key、Codex 与 Claude Code 改 base_url 即用、支付宝/微信充值、按量计费）
- 链接为主站 teamorouter.cn 与站内一篇已上线教程，均为干净 URL，无 utm/推广参数
- 插入位置：新增「2026 年 9 月 8 号添加」日期小节，置于列表顶部（沿用本文件的倒序惯例）