### PR TITLE
添加 Metrune：原生 macOS 专注与开发活动工具

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@
 ### 2026 年 8 月 13 号添加
 
 #### TREAFREE - [Github](https://github.com/TREAFREE)
+* :white_check_mark: [Metrune](https://treafree.github.io/Metrune/)：原生 macOS 专注与开发活动工具，把任务计时、Codex 状态、GitHub 活动和周报收进 Mac 顶部界面，核心记录保存在本地 - [项目与下载](https://github.com/TREAFREE/Metrune)
 * :white_check_mark: [File Island](https://treafree.top/FileIsland/)：原生 macOS 本地媒体转换工具，驻留在 MacBook 刘海区域，支持图片、视频、音频与混合文件夹批量转换，结果可直接拖入访达或聊天应用，文件不上传云端 - [项目与下载](https://github.com/TREAFREE/FileIsland)
 
 #### JeremyGDM - [Github](https://github.com/JeremyGDM)


### PR DESCRIPTION
在已有 TREAFREE 制作者条目下补充 Metrune，保留 File Island，避免重复新增作者。条目按 CONTRIBUTING.md 使用“产品类型 + 核心能力”的一句话介绍。

我是 Metrune 的作者。当前发布版本是 v0.1.0 Community Release，面向 Apple Silicon / macOS 15+，提供任务专注、Codex 状态、GitHub 活动和本地周报。

目前社区版可免费下载；源码采用 PolyForm Noncommercial 1.0.0，属于源码可见，不声称是 OSI 开源。安装包为 ad-hoc 签名、尚未经过 Apple 公证，官网与发布页已说明。条目只描述已发布功能。

已检查：本列表与现有 PR 没有 Metrune；官网、项目及发布链接可访问。

- 官网：https://treafree.github.io/Metrune/
- 发布：https://github.com/TREAFREE/Metrune/releases/tag/v0.1.0
- 授权说明：https://github.com/TREAFREE/Metrune/blob/main/SOURCE_AVAILABLE.md
