### PR TITLE
新增：海克斯小秘书

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@
 #### sweesama - [Github](https://github.com/sweesama)
 * :white_check_mark: [ReadGZH](https://readgzh.site/)：微信公众号文章 AI 阅读工具，粘贴链接生成便于 AI 读取的页面，另提供 API 与 MCP 接入
 
-#### the-beating-light-of-the-nail - [Github](https://github.com/the-beating-light-of-the-nail)
-* :white_check_mark: [海克斯小秘书](https://aramkit.cdqyfdbymn.me/)：《英雄联盟》海克斯大乱斗（ARAM Mayhem）攻略站，选人前查 173 位英雄的实时胜率排行、六神装、技能加点和银/金/棱彩强化符文推荐，三源数据每晚自动聚合，中英日韩等 12 种语言，打开即用无需注册
-
 ### 2026 年 9 月 8 号添加
 
 #### zjzno1 - [Github](https://github.com/zjzno1)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@
 #### sweesama - [Github](https://github.com/sweesama)
 * :white_check_mark: [ReadGZH](https://readgzh.site/)：微信公众号文章 AI 阅读工具，粘贴链接生成便于 AI 读取的页面，另提供 API 与 MCP 接入
 
+#### the-beating-light-of-the-nail - [Github](https://github.com/the-beating-light-of-the-nail)
+* :white_check_mark: [海克斯小秘书](https://aramkit.cdqyfdbymn.me/)：《英雄联盟》海克斯大乱斗（ARAM Mayhem）攻略站，选人前查 173 位英雄的实时胜率排行、六神装、技能加点和银/金/棱彩强化符文推荐，三源数据每晚自动聚合，中英日韩等 12 种语言，打开即用无需注册
+
 ### 2026 年 9 月 8 号添加
 
 #### zjzno1 - [Github](https://github.com/zjzno1)

--- a/pages/README-Game.md
+++ b/pages/README-Game.md
@@ -2,6 +2,11 @@
 
 本版面放的都是游戏，起始于2025年1月4号
 
+### 2026 年 9 月 9 号添加
+
+#### the-beating-light-of-the-nail - [Github](https://github.com/the-beating-light-of-the-nail)
+* :white_check_mark: [海克斯小秘书](https://aramkit.cdqyfdbymn.me/)：《英雄联盟》海克斯大乱斗（ARAM Mayhem）攻略站，选人前查 173 位英雄的实时胜率排行、六神装、技能加点和银/金/棱彩强化符文推荐，三源数据每晚自动聚合，中英日韩等 12 种语言，打开即用无需注册
+
 ### 2026 年 9 月 8 号添加
 
 #### pandaupup(广州) - [Github](https://github.com/pandaupup)


### PR DESCRIPTION
在今天的日期分区添加 **海克斯小秘书**：

- 产品：《英雄联盟》海克斯大乱斗（ARAM Mayhem）攻略站 https://aramkit.cdqyfdbymn.me/
- 打开即用：选人前查 173 位英雄的实时胜率排行、六神装、技能加点和银/金/棱彩强化符文推荐；三源数据每晚自动聚合；中英日韩等 12 种语言，无需注册

我是产品作者，介绍语按 [CONTRIBUTING](../blob/master/CONTRIBUTING.md) 的"写用户能得到什么"原则撰写，格式对照了同分区现有条目。分支基于最新 master（fork 原地切自 upstream）。
