### PR TITLE
修正 XiuStore 条目的中文首页链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@
 * :white_check_mark: [PdfCompare](https://pdfcompare.app/)：免费免登录的在线 PDF 对比与文本转换工具，基于浏览器 WebAssembly 纯本地运行，毫秒级词级红绿高亮差异与图纸图层叠图对比，文档数据 100% 零上传云端，零泄露风险 - [开源仓库](https://github.com/haihiaen/pdf-compare)  
 
 #### Dashu
-* :white_check_mark: [XiuStore](https://store.xiu.ai/en/)：AI 订阅和数字服务商城，商品页公开价格、交付方式、有效期、质保和售后，付款后可在订单中找到对应交付入口
+* :white_check_mark: [XiuStore](https://store.xiu.ai/zh/)：AI 订阅和数字服务商城，商品页公开价格、交付方式、有效期、质保和售后，付款后可在订单中找到对应交付入口
   
 ### 2026 年 9 月 1 号添加
 


### PR DESCRIPTION
现有 XiuStore 条目的介绍是中文，但链接指向英文首页。改为中文首页，让本列表的读者直接看到中文商品与购买说明。

仅将既有链接的 `/en/` 改为 `/zh/`，不新增条目、不修改介绍。

已验证中文目标返回 HTTP 200，页面语言为 `zh-Hans`，canonical 为 `https://store.xiu.ai/zh/`；`git diff --check` 通过。
