### PR TITLE
修正 OPC 情报站条目：线上地址迁移至 opc-radar.pages.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 * :white_check_mark: [AI 智能快照](https://apps.apple.com/cn/app/ai-smart-snapshot/id6796251282?mt=12)：AI 智能快照：截屏、录屏、录音、OCR 识字和标注，一个 App 完成
 
 #### WXzhongwang - [Github](https://github.com/WXzhongwang)
-* :white_check_mark: [OPC 情报站](https://wxzhongwang.github.io/opc-radar/)：一人公司（OPC）资讯聚合站，收录 80 条政策动向、创业案例与生态工具情报，支持 9 大分类筛选、全文搜索与热度排行，纯静态打开即用，无需注册 - [GitHub 仓库](https://github.com/WXzhongwang/opc-radar)
+* :white_check_mark: [OPC 情报站](https://opc-radar.pages.dev/)：一人公司（OPC）资讯聚合站，收录 82 条政策动向、创业案例与生态工具情报，支持 9 大分类筛选、全文搜索与热度排行，纯静态打开即用，无需注册 - [GitHub 仓库](https://github.com/WXzhongwang/opc-radar)
 
 #### 宋永昌(上海) - [Github](https://github.com/yajufurniture-debug)
 * :white_check_mark: [慧报价](https://www.swqifu.com/)：AI 外贸报价工具，产品库一次建好，选品自动按 EXW/FOB/CFR/CIF/DDP 计价（利润率按售价、保险 110% 加成的实务口径），30 秒生成中英双语报价单 PDF，附免费无需注册的报价计算器


### PR DESCRIPTION
列表中的 OPC 情报站条目指向的地址已迁移，顺带同步收录条数。

## 改动

| 项 | 原 | 现 |
| --- | --- | --- |
| 线上地址 | `https://wxzhongwang.github.io/opc-radar/` | `https://opc-radar.pages.dev/` |
| 收录条数 | 80 条 | 82 条 |

原地址仍可访问（GitHub Pages 继续作为备用发布通道），但主域名已切换至 Cloudflare Pages，故将列表中的链接更新为主域名。

`README.md` **+1 −1**，未改动其它任何内容。

## 补充

项目仓库：https://github.com/WXzhongwang/opc-radar

感谢收录。